### PR TITLE
feat(myActivitySchedule): 내 활동 일정 조회 api 추가 #165

### DIFF
--- a/src/main/java/page/clab/api/domain/schedule/api/ScheduleController.java
+++ b/src/main/java/page/clab/api/domain/schedule/api/ScheduleController.java
@@ -60,6 +60,23 @@ public class ScheduleController {
         return responseModel;
     }
 
+    @Operation(summary = "[U] 내 활동 일정 조회", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({"ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER"})
+    @GetMapping("/activity")
+    public ResponseModel getActivitySchedules(
+            @RequestParam(name = "start_date_time") String startDateTime,
+            @RequestParam(name = "end_date_time") String endDateTime,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        PagedResponseDto<ScheduleResponseDto> scheduleResponseDtos
+                = scheduleService.getActivitySchedules(startDateTime, endDateTime, pageable);
+        ResponseModel responseModel = ResponseModel.builder().build();
+        responseModel.addData(scheduleResponseDtos);
+        return responseModel;
+    }
+
     @Operation(summary = "[U] 일정 삭제", description = "ROLE_USER 이상의 권한이 필요함")
     @Secured({"ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER"})
     @DeleteMapping("/{scheduleId}")

--- a/src/main/java/page/clab/api/domain/schedule/domain/Schedule.java
+++ b/src/main/java/page/clab/api/domain/schedule/domain/Schedule.java
@@ -17,6 +17,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
+import page.clab.api.domain.activityGroup.domain.ActivityGroup;
+import page.clab.api.domain.activityGroup.dto.request.ActivityGroupRequestDto;
 import page.clab.api.domain.member.domain.Member;
 import page.clab.api.domain.schedule.dto.request.ScheduleRequestDto;
 
@@ -58,7 +60,9 @@ public class Schedule {
     @JoinColumn(name = "member_id")
     private Member scheduleWriter;
 
-    private Long activityGroupId;
+    @ManyToOne
+    @JoinColumn(name = "activityGroup")
+    private ActivityGroup activityGroup;
 
     public static Schedule of(ScheduleRequestDto scheduleRequestDto) {
         return Schedule.builder()

--- a/src/main/java/page/clab/api/domain/schedule/dto/response/ScheduleResponseDto.java
+++ b/src/main/java/page/clab/api/domain/schedule/dto/response/ScheduleResponseDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import page.clab.api.domain.schedule.domain.Schedule;
+import page.clab.api.domain.schedule.domain.ScheduleType;
 import page.clab.api.global.util.ModelMapperUtil;
 
 @Getter
@@ -22,6 +23,8 @@ public class ScheduleResponseDto {
 
     private String detail;
 
+    private String activityName;
+
     private LocalDateTime startDate;
 
     private LocalDateTime endDate;
@@ -29,6 +32,10 @@ public class ScheduleResponseDto {
     public static ScheduleResponseDto of(Schedule schedule) {
         ScheduleResponseDto scheduleResponseDto = ModelMapperUtil.getModelMapper()
                 .map(schedule, ScheduleResponseDto.class);
+
+        if (schedule.getScheduleType() != ScheduleType.ALL) {
+            scheduleResponseDto.setActivityName(schedule.getActivityGroup().getName());
+        }
 
         return scheduleResponseDto;
     }


### PR DESCRIPTION
## Summary

> 내 활동 일정 조회 api 추가


## Tasks

- 내 활동 일정 조회 api 추가

## ETC
일정의 종류에 따라서 활동명을 null로 할지 실제 활동명을 전달할지 판단했습니다. 아래 사진 첨부 하겠습니다!

## Screenshot
전체 일정 조회 시 ALL의 경우는 활동이름 null로 나오고 활동일 경우에만 실제 활동명 전달
![image](https://github.com/KGU-C-Lab/clab-server/assets/96719969/49ff7bfa-acd1-4b4c-9795-cc9e804208f3)

내 활동 일정 조회 시 활동이름 전달
![image](https://github.com/KGU-C-Lab/clab-server/assets/96719969/f80ea37d-e8b4-4573-9345-5f9c03d73478)

