### PR TITLE
refactor: 이달의 생일자 조회 API의 month 파라미터 타입을 String에서 int로 변경

### DIFF
--- a/src/main/java/page/clab/api/domain/member/api/MemberController.java
+++ b/src/main/java/page/clab/api/domain/member/api/MemberController.java
@@ -74,7 +74,7 @@ public class MemberController {
     @Secured({"ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER"})
     @GetMapping("/birthday")
     public ResponseModel getBirthdaysThisMonth(
-            @RequestParam(name = "month") String month,
+            @RequestParam(name = "month") int month,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size
     ) {

--- a/src/main/java/page/clab/api/domain/member/application/MemberService.java
+++ b/src/main/java/page/clab/api/domain/member/application/MemberService.java
@@ -95,8 +95,8 @@ public class MemberService {
         return new PagedResponseDto<>(members.map(MemberResponseDto::of));
     }
 
-    public PagedResponseDto<MemberResponseDto> getBirthdaysThisMonth(String month, Pageable pageable) {
-        LocalDate currentMonth = LocalDate.now().withMonth(Integer.parseInt(month));
+    public PagedResponseDto<MemberResponseDto> getBirthdaysThisMonth(int month, Pageable pageable) {
+        LocalDate currentMonth = LocalDate.now().withMonth(month);
         List<Member> members = memberRepository.findAll();
         List<Member> birthdayMembers = members.stream()
                 .filter(member -> member.getBirth().getMonth() == currentMonth.getMonth())


### PR DESCRIPTION
## Summary

> 이달의 생일자 조회 API의 month 파라미터 타입을 String에서 int로 변경

String으로 값을 받아 int로 변환하여 사용했던 불필요한 로직을 개선

## Tasks

- 이달의 생일자 조회 API의 month 파라미터 타입을 String에서 int로 변경

## ETC

## Screenshot
