### PR TITLE
fix: 도서 정보 수정시 version 칼럼이 null이 되어 500 에러가 발생하는 문제 수정

### DIFF
--- a/src/main/java/page/clab/api/domain/book/application/BookService.java
+++ b/src/main/java/page/clab/api/domain/book/application/BookService.java
@@ -6,10 +6,6 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -21,6 +17,11 @@ import page.clab.api.domain.book.dto.request.BookRequestDto;
 import page.clab.api.domain.book.dto.response.BookResponseDto;
 import page.clab.api.global.common.dto.PagedResponseDto;
 import page.clab.api.global.exception.NotFoundException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -73,6 +74,7 @@ public class BookService {
         updatedBook.setId(book.getId());
         updatedBook.setCreatedAt(book.getCreatedAt());
         updatedBook.setBorrower(book.getBorrower());
+        updatedBook.setVersion(book.getVersion());
         return bookRepository.save(updatedBook).getId();
     }
 


### PR DESCRIPTION
## Summary

> 도서 정보 수정 오류 해결

동시성 처리할 때 추가된 version 칼럼이 null이 되어 500 에러가 발생하는 문제 수정

## Tasks

- 도서 정보 수정 오류 해결

## ETC

## Screenshot
