### PR TITLE
fix(AuthUtil): 토큰 없이 API 접근할 때 500에러가 발생하는 오류 수정

### DIFF
--- a/src/main/java/page/clab/api/global/auth/exception/AuthenticationInfoNotFoundException.java
+++ b/src/main/java/page/clab/api/global/auth/exception/AuthenticationInfoNotFoundException.java
@@ -1,0 +1,15 @@
+package page.clab.api.global.auth.exception;
+
+public class AuthenticationInfoNotFoundException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "No authentication information available.";
+
+    public AuthenticationInfoNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public AuthenticationInfoNotFoundException(String s) {
+        super(s);
+    }
+
+}

--- a/src/main/java/page/clab/api/global/auth/util/AuthUtil.java
+++ b/src/main/java/page/clab/api/global/auth/util/AuthUtil.java
@@ -3,15 +3,20 @@ package page.clab.api.global.auth.util;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
+import page.clab.api.global.auth.exception.AuthenticationInfoNotFoundException;
 
 public class AuthUtil {
 
     public static User getAuthenticationInfo() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || authentication.getName() == null) {
-            throw new RuntimeException("No authentication information.");
+            throw new AuthenticationInfoNotFoundException();
         }
-        return (User) authentication.getPrincipal();
+        if (authentication.getPrincipal() instanceof User) {
+            return (User) authentication.getPrincipal();
+        } else {
+            throw new AuthenticationInfoNotFoundException("Authentication principal is not of type User.");
+        }
     }
 
     public static String getAuthenticationInfoMemberId() {

--- a/src/main/java/page/clab/api/global/handler/ControllerExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/ControllerExceptionHandler.java
@@ -41,6 +41,7 @@ import page.clab.api.domain.member.exception.AssociatedAccountExistsException;
 import page.clab.api.domain.review.exception.AlreadyReviewedException;
 import page.clab.api.domain.sharedAccount.exception.SharedAccountInUseException;
 import page.clab.api.domain.sharedAccount.exception.SharedAccountUsageStateException;
+import page.clab.api.global.auth.exception.AuthenticationInfoNotFoundException;
 import page.clab.api.global.auth.exception.TokenValidateException;
 import page.clab.api.global.auth.exception.UnAuthorizeException;
 import page.clab.api.global.common.dto.ResponseModel;
@@ -92,6 +93,7 @@ public class ControllerExceptionHandler {
     }
 
     @ExceptionHandler({
+            AuthenticationInfoNotFoundException.class,
             UnAuthorizeException.class,
             AccessDeniedException.class,
             LoginFaliedException.class,


### PR DESCRIPTION
## Summary

> 토큰 없이 API 접근할 때 500에러가 발생하는 오류 수정

## Tasks

- Authentication을 User로 변환할 때 타입이 일치하지 않는 경우 500에러를 발생하지 않고 예외를 던지도록 수정

## ETC

## Screenshot
