### PR TITLE
동아리 지원서 작성 시 이모지 처리 버그

### DIFF
--- a/src/main/java/page/clab/api/global/config/XssProtectConfig.java
+++ b/src/main/java/page/clab/api/global/config/XssProtectConfig.java
@@ -1,0 +1,26 @@
+package page.clab.api.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import page.clab.api.global.util.HtmlCharacterEscapes;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class XssProtectConfig {
+
+    private final ObjectMapper mapper;
+
+    @Bean
+    public MappingJackson2HttpMessageConverter characterEscapeConverter() {
+        ObjectMapper objectMapper = mapper.copy();
+        objectMapper.getFactory().setCharacterEscapes(new HtmlCharacterEscapes());
+        return new MappingJackson2HttpMessageConverter(objectMapper);
+    }
+}
+
+

--- a/src/main/java/page/clab/api/global/util/HtmlCharacterEscapes.java
+++ b/src/main/java/page/clab/api/global/util/HtmlCharacterEscapes.java
@@ -9,6 +9,8 @@ public class HtmlCharacterEscapes extends CharacterEscapes {
 
     private final int[] asciiEscapes;
 
+    private static final char ZERO_WIDTH_JOINER = 0x200D;
+
     public HtmlCharacterEscapes() {
         asciiEscapes = CharacterEscapes.standardAsciiEscapesForJSON();
         asciiEscapes['<'] = CharacterEscapes.ESCAPE_CUSTOM;
@@ -25,9 +27,16 @@ public class HtmlCharacterEscapes extends CharacterEscapes {
         return asciiEscapes;
     }
 
-
     @Override
     public SerializableString getEscapeSequence(int ch) {
-        return new SerializedString(StringEscapeUtils.escapeHtml4(Character.toString((char) ch)));
+        char charAt = (char)ch;
+        if (Character.isHighSurrogate(charAt) || Character.isLowSurrogate(charAt) || charAt == ZERO_WIDTH_JOINER) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("\\u");
+            sb.append(String.format("%04x", ch));
+            return new SerializedString(sb.toString());
+        } else {
+            return new SerializedString(StringEscapeUtils.escapeHtml4(Character.toString(charAt)));
+        }
     }
 }


### PR DESCRIPTION
## Summary

>동아리 지원서 작성 시 특정 이모지를 사용할 경우 post는 되지만 지원서 조회 api에서 500에러 발생

## Tasks

- 이모지 사용 가능하도록 response시 character 확인

## ETC
Character 클래스 내부에 surrogate pair 과 관련되 4개의 상수를 사용해서 범위에 맞으면 알맞은 조취를 취할 수 있도록 로직 추가

## Screenshot
![image](https://github.com/KGU-C-Lab/clab-server/assets/96719969/0370f071-9f05-4621-9ca6-35db81823313)
![image](https://github.com/KGU-C-Lab/clab-server/assets/96719969/4ae7ff78-2599-45ed-8d68-8e7119071038)

