### PR TITLE
fix: 토큰이 존재하지 않을 때 상태코드 500이 반환되는 문제 수정

### DIFF
--- a/src/main/java/page/clab/api/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/JwtAuthenticationFilter.java
@@ -15,8 +15,6 @@ import page.clab.api.domain.blacklistIp.dao.BlacklistIpRepository;
 import page.clab.api.domain.login.application.RedisTokenService;
 import page.clab.api.domain.login.domain.RedisToken;
 import page.clab.api.global.auth.application.RedisIpAccessMonitorService;
-import page.clab.api.global.auth.exception.TokenMisuseException;
-import page.clab.api.global.auth.exception.TokenNotFoundException;
 import page.clab.api.global.auth.jwt.JwtTokenProvider;
 import page.clab.api.global.common.slack.application.SlackService;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
@@ -42,16 +40,20 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        String path = ((HttpServletRequest) request).getRequestURI();
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+        String path = httpServletRequest.getRequestURI();
         if (SwaggerUtil.isSwaggerRequest(path)) {
             chain.doFilter(request, response);
             return;
         }
         String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
-        if (!verifyIpAddressAccess((HttpServletResponse) response, clientIpAddress)) {
+        if (!verifyIpAddressAccess(httpServletResponse, clientIpAddress)) {
             return;
         }
-        authenticateToken((HttpServletRequest) request, clientIpAddress);
+        if (!authenticateToken(httpServletRequest, httpServletResponse, clientIpAddress)) {
+            return;
+        }
         chain.doFilter(request, response);
     }
 
@@ -64,20 +66,27 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         return true;
     }
 
-    private void authenticateToken(HttpServletRequest request, String clientIpAddress) {
+    private boolean authenticateToken(HttpServletRequest request, HttpServletResponse response, String clientIpAddress) throws IOException {
         String token = jwtTokenProvider.resolveToken(request);
         if (token != null && jwtTokenProvider.validateToken(token)) {
-            RedisToken redisToken = (jwtTokenProvider.isRefreshToken(token)) ? redisTokenService.getRedisTokenByRefreshToken(token) : redisTokenService.getRedisTokenByAccessToken(token);
+            RedisToken redisToken = jwtTokenProvider.isRefreshToken(token) ? redisTokenService.getRedisTokenByRefreshToken(token) : redisTokenService.getRedisTokenByAccessToken(token);
             if (redisToken == null) {
-                throw new TokenNotFoundException("존재하지 않는 토큰입니다.");
+                log.warn("존재하지 않는 토큰입니다.");
+                ResponseUtil.sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED);
+                return false;
             }
             if (!redisToken.getIp().equals(clientIpAddress)) {
                 redisTokenService.deleteRedisTokenByAccessToken(token);
                 slackService.sendSecurityAlertNotification(request, SecurityAlertType.DUPLICATE_LOGIN, "토큰 발급 IP와 다른 IP에서 접속하여 토큰을 삭제하였습니다.");
-                throw new TokenMisuseException("[" + clientIpAddress + "] 토큰 발급 IP와 다른 IP에서 접속하여 토큰을 삭제하였습니다.");
+                log.warn("[{}] 토큰 발급 IP와 다른 IP에서 접속하여 토큰을 삭제하였습니다.", clientIpAddress);
+                ResponseUtil.sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED);
+                return false;
             }
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
+            return true;
+        } else {
+            return true;
         }
     }
 

--- a/src/main/java/page/clab/api/global/util/ResponseUtil.java
+++ b/src/main/java/page/clab/api/global/util/ResponseUtil.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 public class ResponseUtil {
 
     public static void sendErrorResponse(HttpServletResponse response, int status) throws IOException {
-        ResponseModel responseModel = page.clab.api.global.common.dto.ResponseModel.builder()
+        ResponseModel responseModel = ResponseModel.builder()
                 .success(false)
                 .build();
         response.getWriter().write(responseModel.toJson());


### PR DESCRIPTION
## Summary

> JwtAuthenticationFilter에서 Exception을 발생시킬 경우 ExceptionHandler에 Exception이 전달되지 않는걸 발견

오류가 발생할 경우 필터 체인의 진행을 중단하고 다음을 반환
상태코드: 401
Body:
{
  "success": false,
  "data": null
}

## Tasks

- 토큰이 존재하지 않을 때 상태코드 500이 반환되는 문제 수정

## ETC

## Screenshot
