### PR TITLE
refactor: 활동 그룹 게시판 조회 요청 최적화

### DIFF
--- a/src/main/java/page/clab/api/domain/activityGroup/api/ActivityGroupBoardController.java
+++ b/src/main/java/page/clab/api/domain/activityGroup/api/ActivityGroupBoardController.java
@@ -10,7 +10,6 @@ import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,9 +22,12 @@ import page.clab.api.domain.activityGroup.dto.request.ActivityGroupBoardUpdateRe
 import page.clab.api.domain.activityGroup.dto.response.ActivityGroupBoardChildResponseDto;
 import page.clab.api.domain.activityGroup.dto.response.ActivityGroupBoardResponseDto;
 import page.clab.api.domain.activityGroup.dto.response.ActivityGroupBoardUpdateResponseDto;
+import page.clab.api.domain.activityGroup.dto.response.AssignmentSubmissionWithFeedbackResponseDto;
 import page.clab.api.global.common.dto.PagedResponseDto;
 import page.clab.api.global.common.dto.ResponseModel;
 import page.clab.api.global.exception.PermissionDeniedException;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/activity-group/boards")
@@ -98,16 +100,6 @@ public class ActivityGroupBoardController {
         return responseModel;
     }
 
-    @Operation(summary = "[U] 제출 게시판에 대한 유일한 피드백 게시판 조회", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({"ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER"})
-    @GetMapping("/{parentId}")
-    public ResponseModel getFeedbackCategoryBoardByParent(@PathVariable Long parentId) {
-        ActivityGroupBoardResponseDto board = activityGroupBoardService.getFeedbackCategoryBoardByParent(parentId);
-        ResponseModel responseModel = ResponseModel.builder().build();
-        responseModel.addData(board);
-        return responseModel;
-    }
-
     @Operation(summary = "[U] 활동 그룹 게시판 계층 구조적 조회, 부모 및 자식 게시판 함께 반환", description = "ROLE_USER 이상의 권한이 필요함")
     @Secured({"ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER"})
     @GetMapping("/by-parent")
@@ -123,15 +115,15 @@ public class ActivityGroupBoardController {
         return responseModel;
     }
 
-    @Operation(summary = "[U] 나의 과제 제출 게시판 조회", description = "ROLE_USER 이상의 권한이 필요함")
+    @Operation(summary = "[U] 나의 제출 과제 및 피드백 조회", description = "ROLE_USER 이상의 권한이 필요함")
     @Secured({"ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER"})
     @GetMapping("/my-assignment")
-    public ResponseModel getMyAssignmentBoard(
+    public ResponseModel getMyAssignmentBoardWithFeedback(
             @RequestParam(name = "parentId") Long parentId
     ) {
-        ActivityGroupBoardResponseDto board = activityGroupBoardService.getMyAssignmentBoard(parentId);
+        List<AssignmentSubmissionWithFeedbackResponseDto> submissionWithFeedbacks = activityGroupBoardService.getMyAssignmentsWithFeedbacks(parentId);
         ResponseModel responseModel = ResponseModel.builder().build();
-        responseModel.addData(board);
+        responseModel.addData(submissionWithFeedbacks);
         return responseModel;
     }
 

--- a/src/main/java/page/clab/api/domain/activityGroup/application/ActivityGroupBoardService.java
+++ b/src/main/java/page/clab/api/domain/activityGroup/application/ActivityGroupBoardService.java
@@ -18,8 +18,9 @@ import page.clab.api.domain.activityGroup.dto.request.ActivityGroupBoardUpdateRe
 import page.clab.api.domain.activityGroup.dto.response.ActivityGroupBoardChildResponseDto;
 import page.clab.api.domain.activityGroup.dto.response.ActivityGroupBoardResponseDto;
 import page.clab.api.domain.activityGroup.dto.response.ActivityGroupBoardUpdateResponseDto;
+import page.clab.api.domain.activityGroup.dto.response.AssignmentSubmissionWithFeedbackResponseDto;
+import page.clab.api.domain.activityGroup.dto.response.FeedbackResponseDto;
 import page.clab.api.domain.activityGroup.exception.InvalidParentBoardException;
-import page.clab.api.domain.activityGroup.exception.NotSubmitCategoryBoardException;
 import page.clab.api.domain.member.application.MemberService;
 import page.clab.api.domain.member.domain.Member;
 import page.clab.api.domain.notification.application.NotificationService;
@@ -139,33 +140,24 @@ public class ActivityGroupBoardService {
         return new PagedResponseDto<>(boardPage.map(ActivityGroupBoardChildResponseDto::of));
     }
 
-    public ActivityGroupBoardResponseDto getFeedbackCategoryBoardByParent(Long parentId) {
-        ActivityGroupBoard parentBoard = activityGroupBoardRepository.findById(parentId)
-                .orElseThrow(() -> new NotFoundException("부모 게시판이 존재하지 않습니다."));
-
-        if (!parentBoard.getCategory().equals(ActivityGroupBoardCategory.SUBMIT)) {
-            throw new NotSubmitCategoryBoardException("제출 카테고리 게시판이 아니기 때문에 피드백 카테고리 게시판을 찾을 수 없습니다.");
-        }
-
-        if (parentBoard.getChildren().size() != 1) {
-            throw new NotFoundException("피드백 카테고리 게시판이 없거나 유일하지 않습니다.");
-        }
-
-        Long childId = parentBoard.getChildren().getFirst().getId();
-        return getActivityGroupBoardById(childId);
-    }
-
-    public ActivityGroupBoardResponseDto getMyAssignmentBoard(Long parentId) {
-        Member member = memberService.getCurrentMember();
+    @Transactional
+    public List<AssignmentSubmissionWithFeedbackResponseDto> getMyAssignmentsWithFeedbacks(Long parentId) {
+        Member currentMember = memberService.getCurrentMember();
         ActivityGroupBoard parentBoard = getActivityGroupBoardByIdOrThrow(parentId);
-        List<ActivityGroupBoard> childrenBoards = parentBoard.getChildren();
-        List<ActivityGroupBoard> assignmentBoard = childrenBoards.stream()
-                .filter(child -> child.getCategory() == ActivityGroupBoardCategory.SUBMIT && child.getMember().getId().equals(member.getId()))
-                .collect(Collectors.toList());
-        if (assignmentBoard.isEmpty()) {
-            throw new NotFoundException("제출한 과제가 없습니다.");
+        List<ActivityGroupBoard> mySubmissions = parentBoard.getChildren().stream()
+                .filter(child -> child.getCategory() == ActivityGroupBoardCategory.SUBMIT && child.getMember().equals(currentMember))
+                .toList();
+        List<AssignmentSubmissionWithFeedbackResponseDto> submissionsWithFeedbacks = new ArrayList<>();
+        for (ActivityGroupBoard submission : mySubmissions) {
+            AssignmentSubmissionWithFeedbackResponseDto submissionDto = AssignmentSubmissionWithFeedbackResponseDto.of(submission);
+            List<FeedbackResponseDto> feedbackDtos = submission.getChildren().stream()
+                    .filter(feedback -> feedback.getCategory() == ActivityGroupBoardCategory.FEEDBACK)
+                    .map(FeedbackResponseDto::of)
+                    .toList();
+            submissionDto.setFeedbacks(feedbackDtos);
+            submissionsWithFeedbacks.add(submissionDto);
         }
-        return getActivityGroupBoardById(assignmentBoard.get(0).getId());
+        return submissionsWithFeedbacks;
     }
 
     public ActivityGroupBoardUpdateResponseDto updateActivityGroupBoard(Long activityGroupBoardId, ActivityGroupBoardUpdateRequestDto activityGroupBoardUpdateRequestDto) throws PermissionDeniedException {

--- a/src/main/java/page/clab/api/domain/activityGroup/dto/response/AssignmentSubmissionWithFeedbackResponseDto.java
+++ b/src/main/java/page/clab/api/domain/activityGroup/dto/response/AssignmentSubmissionWithFeedbackResponseDto.java
@@ -1,0 +1,44 @@
+package page.clab.api.domain.activityGroup.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import page.clab.api.domain.activityGroup.domain.ActivityGroupBoard;
+import page.clab.api.global.common.file.dto.response.UploadedFileResponseDto;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AssignmentSubmissionWithFeedbackResponseDto {
+
+    private Long id;
+
+    private Long parentId;
+
+    private List<UploadedFileResponseDto> files = new ArrayList<>();
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updateTime;
+
+    private List<FeedbackResponseDto> feedbacks = new ArrayList<>();
+
+    public static AssignmentSubmissionWithFeedbackResponseDto of(ActivityGroupBoard activityGroupBoard) {
+        return AssignmentSubmissionWithFeedbackResponseDto.builder()
+                .id(activityGroupBoard.getId())
+                .parentId(activityGroupBoard.getParent() != null ? activityGroupBoard.getParent().getId() : null)
+                .files(activityGroupBoard.getUploadedFiles().stream().map(UploadedFileResponseDto::of).toList())
+                .createdAt(activityGroupBoard.getCreatedAt())
+                .updateTime(activityGroupBoard.getUpdateTime())
+                .build();
+    }
+
+}

--- a/src/main/java/page/clab/api/domain/activityGroup/dto/response/FeedbackResponseDto.java
+++ b/src/main/java/page/clab/api/domain/activityGroup/dto/response/FeedbackResponseDto.java
@@ -1,0 +1,42 @@
+package page.clab.api.domain.activityGroup.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import page.clab.api.domain.activityGroup.domain.ActivityGroupBoard;
+import page.clab.api.global.common.file.dto.response.UploadedFileResponseDto;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FeedbackResponseDto {
+
+    private Long id;
+
+    private String content;
+
+    private List<UploadedFileResponseDto> files = new ArrayList<>();
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updateTime;
+
+    public static FeedbackResponseDto of(ActivityGroupBoard activityGroupBoard) {
+        return FeedbackResponseDto.builder()
+                .id(activityGroupBoard.getId())
+                .content(activityGroupBoard.getContent())
+                .files(activityGroupBoard.getUploadedFiles().stream().map(UploadedFileResponseDto::of).toList())
+                .createdAt(activityGroupBoard.getCreatedAt())
+                .updateTime(activityGroupBoard.getUpdateTime())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## Summary

> 활동 그룹 게시판 조회 요청 최적화

기존: 과제 게시판에 들어갔을 때 [해당 게시판, 나의 과제, 과제에 대한 피드백]에 대한 조회가 발생
수정: 나의 과제, 과제에 대한 피드백 조회를 통합하여 요청을 3회에서 2회로 줄임

## Tasks

- 나의 과제 제출 게시판 조회시 과제에 대한 피드백을 같이 반환

## ETC

## Screenshot
