### PR TITLE
슬랙 알림 최소화 및 채널 구분 완료

### DIFF
--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -181,7 +181,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage '${FAILED_STAGE}' failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage ${FAILED_STAGE} failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage *${FAILED_STAGE}* failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage **${FAILED_STAGE}** failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -181,7 +181,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage ${FAILED_STAGE} failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage *`${FAILED_STAGE}`* failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -112,8 +112,6 @@ pipeline {
             steps {
                 script {
                     FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
-                    echo "FAILED_STAGE value is ${FAILED_STAGE}"
                     dockerLogin()
                 }
             }
@@ -123,8 +121,6 @@ pipeline {
             steps {
                 script {
                     FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
-                    echo "FAILED_STAGE value is ${FAILED_STAGE}"
                     determineContainers()
                 }
             }
@@ -134,8 +130,6 @@ pipeline {
             steps {
                 script {
                     FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
-                    echo "FAILED_STAGE value is ${FAILED_STAGE}"
                     buildApplication()
                 }
             }

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -17,10 +17,12 @@
  * Ensure the plugin is up-to-date to avoid compatibility issues.
  */
 
-def FAILED_STAGE = ""
-
 pipeline {
     agent any
+
+    environment {
+        FAILED_STAGE = ""
+    }
 
     triggers {
         githubPush()
@@ -30,7 +32,7 @@ pipeline {
         stage('Load Environment Variables') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                 }
                 withCredentials([file(credentialsId: 'members_prod_config_yml', variable: 'CONFIG_FILE')]) {
                     script {
@@ -84,7 +86,7 @@ pipeline {
         stage('Check Java Version') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                 }
                 sh 'java -version'
             }
@@ -93,7 +95,7 @@ pipeline {
         stage('Get Git Change Log') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                     env.GIT_CHANGELOG = getChangeLog()
                 }
             }
@@ -102,7 +104,7 @@ pipeline {
         stage('PostgreSQL Backup') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                     backupPostgres()
                 }
             }
@@ -111,7 +113,7 @@ pipeline {
         stage('Docker Hub Login') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                     dockerLogin()
                 }
             }
@@ -120,7 +122,7 @@ pipeline {
         stage('Determine Containers') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                     determineContainers()
                 }
             }
@@ -129,7 +131,7 @@ pipeline {
         stage('Build Application') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                     buildApplication()
                 }
             }
@@ -138,7 +140,7 @@ pipeline {
         stage('Build and Push Docker Image') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                     buildAndPushDockerImage()
                 }
             }
@@ -147,7 +149,7 @@ pipeline {
         stage('Deploy New Instance') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                     deployNewInstance()
                 }
             }
@@ -156,7 +158,7 @@ pipeline {
         stage('Health Check') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                     performHealthCheck()
                 }
             }
@@ -165,7 +167,7 @@ pipeline {
         stage('Switch Traffic and Cleanup') {
             steps {
                 script {
-                    FAILED_STAGE = env.STAGE_NAME
+                    env.FAILED_STAGE = env.STAGE_NAME
                     switchTrafficAndCleanup()
                 }
             }
@@ -175,7 +177,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage '${FAILED_STAGE}' failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage '${env.FAILED_STAGE}' failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -181,7 +181,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage *`${FAILED_STAGE}`* failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage *${FAILED_STAGE}* failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -129,6 +129,7 @@ pipeline {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
                     determineContainers()
                 }
             }
@@ -139,6 +140,7 @@ pipeline {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
                     buildApplication()
                 }
             }
@@ -149,6 +151,7 @@ pipeline {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
                     buildAndPushDockerImage()
                 }
             }
@@ -159,6 +162,7 @@ pipeline {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
                     deployNewInstance()
                 }
             }
@@ -169,6 +173,7 @@ pipeline {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
                     performHealthCheck()
                 }
             }
@@ -188,7 +193,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage '${env.FAILED_STAGE}' failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage ${env.FAILED_STAGE} failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     stages {
         stage('Load Environment Variables') {
             steps {
-                withCredentials([file(credentialsId: 'platforms_prod_config_yml', variable: 'CONFIG_FILE')]) {
+                withCredentials([file(credentialsId: 'members_prod_config_yml', variable: 'CONFIG_FILE')]) {
                     script {
                         def config = readYaml(file: env.CONFIG_FILE)
 
@@ -75,18 +75,24 @@ pipeline {
                     }
                 }
             }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Load Environment Variables' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('Check Java Version') {
             steps {
                 sh 'java -version'
             }
-        }
-
-        stage('Slack Notification: Production Server Testing') {
-            steps {
-                script {
-                    sendSlackNotification(":test_tube: Testing the Production server...", env.SLACK_COLOR_SUCCESS)
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Check Java Version' failed.", env.SLACK_COLOR_FAILURE)
+                    }
                 }
             }
         }
@@ -97,12 +103,26 @@ pipeline {
                     env.GIT_CHANGELOG = getChangeLog()
                 }
             }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Get Git Change Log' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('PostgreSQL Backup') {
             steps {
                 script {
                     backupPostgres()
+                }
+            }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'PostgreSQL Backup' failed.", env.SLACK_COLOR_FAILURE)
+                    }
                 }
             }
         }
@@ -113,12 +133,26 @@ pipeline {
                     dockerLogin()
                 }
             }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Docker Hub Login' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('Determine Containers') {
             steps {
                 script {
                     determineContainers()
+                }
+            }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Determine Containers' failed.", env.SLACK_COLOR_FAILURE)
+                    }
                 }
             }
         }
@@ -129,12 +163,26 @@ pipeline {
                     buildApplication()
                 }
             }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Build Application' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('Build and Push Docker Image') {
             steps {
                 script {
                     buildAndPushDockerImage()
+                }
+            }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Build and Push Docker Image' failed.", env.SLACK_COLOR_FAILURE)
+                    }
                 }
             }
         }
@@ -145,6 +193,13 @@ pipeline {
                     deployNewInstance()
                 }
             }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Deploy New Instance' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('Health Check') {
@@ -153,12 +208,26 @@ pipeline {
                     performHealthCheck()
                 }
             }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Health Check' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('Switch Traffic and Cleanup') {
             steps {
                 script {
                     switchTrafficAndCleanup()
+                }
+            }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Switch Traffic and Cleanup' failed.", env.SLACK_COLOR_FAILURE)
+                    }
                 }
             }
         }
@@ -178,25 +247,6 @@ pipeline {
         }
     }
 }
-
-def sendSlackNotification(String message, String color) {
-    def payload = [
-        attachments: [
-            [
-                color: color,
-                text: message.replaceAll('"', '\\"').replaceAll('\n', '\\\\n')
-            ]
-        ]
-    ]
-
-    withEnv(["SLACK_WEBHOOK_URL=${env.SLACK_WEBHOOK_URL}"]) {
-        def payloadJson = groovy.json.JsonOutput.toJson(payload)
-        sh """
-            curl -X POST -H 'Content-type: application/json' --data '${payloadJson}' ${SLACK_WEBHOOK_URL}
-        """
-    }
-}
-
 
 def sendSlackBuildNotification(String message, String color) {
     def jobUrl = "${env.JENKINS_DOMAIN}/job/${env.JOB_NAME}"
@@ -291,7 +341,6 @@ def backupPostgres() {
             docker exec -e PGPASSWORD=${PG_PASSWORD} ${POSTGRESQL_CONTAINER_NAME} sh -c 'pg_dumpall -c -U ${PG_USER} > ${BACKUP_DIR}/${BACKUP_FILE}'
         """
     }
-    sendSlackNotification(":floppy_disk: PostgreSQL backup completed successfully: ${BACKUP_FILE}", env.SLACK_COLOR_SUCCESS)
 }
 
 def dockerLogin() {
@@ -403,7 +452,6 @@ def deployNewInstance() {
             docker ps -a
         """
     }
-    sendSlackNotification(":low_battery: Restarting the Production server...", env.SLACK_COLOR_SUCCESS)
 }
 
 def performHealthCheck() {
@@ -433,7 +481,6 @@ def performHealthCheck() {
         }
 
         if (System.currentTimeMillis() >= timeout) {
-            sendSlackNotification(":scream_cat: New Production application did not start successfully within 2.5 minutes.", env.SLACK_COLOR_FAILURE)
             sh "docker stop ${env.DEPLOY_CONTAINER}"
             sh "docker rm ${env.DEPLOY_CONTAINER}"
             error "Health check failed"

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -17,12 +17,10 @@
  * Ensure the plugin is up-to-date to avoid compatibility issues.
  */
 
+def FAILED_STAGE = ""
+
 pipeline {
     agent any
-
-    environment {
-        FAILED_STAGE = ""
-    }
 
     triggers {
         githubPush()
@@ -32,8 +30,7 @@ pipeline {
         stage('Load Environment Variables') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    FAILED_STAGE = env.STAGE_NAME
                 }
                 withCredentials([file(credentialsId: 'members_prod_config_yml', variable: 'CONFIG_FILE')]) {
                     script {
@@ -87,8 +84,7 @@ pipeline {
         stage('Check Java Version') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    FAILED_STAGE = env.STAGE_NAME
                 }
                 sh 'java -version'
             }
@@ -97,8 +93,7 @@ pipeline {
         stage('Get Git Change Log') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    FAILED_STAGE = env.STAGE_NAME
                     env.GIT_CHANGELOG = getChangeLog()
                 }
             }
@@ -107,8 +102,7 @@ pipeline {
         stage('PostgreSQL Backup') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    FAILED_STAGE = env.STAGE_NAME
                     backupPostgres()
                 }
             }
@@ -117,8 +111,9 @@ pipeline {
         stage('Docker Hub Login') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
+                    FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
                     dockerLogin()
                 }
             }
@@ -127,7 +122,7 @@ pipeline {
         stage('Determine Containers') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
+                    FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
                     determineContainers()
@@ -138,7 +133,7 @@ pipeline {
         stage('Build Application') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
+                    FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
                     buildApplication()
@@ -149,9 +144,7 @@ pipeline {
         stage('Build and Push Docker Image') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
-                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
+                    FAILED_STAGE = env.STAGE_NAME
                     buildAndPushDockerImage()
                 }
             }
@@ -160,9 +153,7 @@ pipeline {
         stage('Deploy New Instance') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
-                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
+                    FAILED_STAGE = env.STAGE_NAME
                     deployNewInstance()
                 }
             }
@@ -171,9 +162,7 @@ pipeline {
         stage('Health Check') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
-                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
+                    FAILED_STAGE = env.STAGE_NAME
                     performHealthCheck()
                 }
             }
@@ -182,8 +171,7 @@ pipeline {
         stage('Switch Traffic and Cleanup') {
             steps {
                 script {
-                    env.FAILED_STAGE = env.STAGE_NAME
-                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
+                    FAILED_STAGE = env.STAGE_NAME
                     switchTrafficAndCleanup()
                 }
             }
@@ -193,7 +181,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage ${env.FAILED_STAGE} failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage '${FAILED_STAGE}' failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage **${FAILED_STAGE}** failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage *${FAILED_STAGE}* failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
                 script {
                     FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
-                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
+                    echo "FAILED_STAGE value is ${FAILED_STAGE}"
                     dockerLogin()
                 }
             }
@@ -124,7 +124,7 @@ pipeline {
                 script {
                     FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
-                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
+                    echo "FAILED_STAGE value is ${FAILED_STAGE}"
                     determineContainers()
                 }
             }
@@ -135,7 +135,7 @@ pipeline {
                 script {
                     FAILED_STAGE = env.STAGE_NAME
                     echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
-                    echo "FAILED_STAGE value is ${env.FAILED_STAGE}"
+                    echo "FAILED_STAGE value is ${FAILED_STAGE}"
                     buildApplication()
                 }
             }

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -17,6 +17,7 @@
  * Ensure the plugin is up-to-date to avoid compatibility issues.
  */
 
+def FAILED_STAGE = ""
 
 pipeline {
     agent any
@@ -28,6 +29,9 @@ pipeline {
     stages {
         stage('Load Environment Variables') {
             steps {
+                script {
+                    FAILED_STAGE = env.STAGE_NAME
+                }
                 withCredentials([file(credentialsId: 'members_prod_config_yml', variable: 'CONFIG_FILE')]) {
                     script {
                         def config = readYaml(file: env.CONFIG_FILE)
@@ -75,39 +79,22 @@ pipeline {
                     }
                 }
             }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Load Environment Variables' failed.", env.SLACK_COLOR_FAILURE)
-                    }
-                }
-            }
         }
 
         stage('Check Java Version') {
             steps {
-                sh 'java -version'
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Check Java Version' failed.", env.SLACK_COLOR_FAILURE)
-                    }
+                script {
+                    FAILED_STAGE = env.STAGE_NAME
                 }
+                sh 'java -version'
             }
         }
 
         stage('Get Git Change Log') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     env.GIT_CHANGELOG = getChangeLog()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Get Git Change Log' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -115,14 +102,8 @@ pipeline {
         stage('PostgreSQL Backup') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     backupPostgres()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'PostgreSQL Backup' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -130,14 +111,8 @@ pipeline {
         stage('Docker Hub Login') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     dockerLogin()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Docker Hub Login' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -145,14 +120,8 @@ pipeline {
         stage('Determine Containers') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     determineContainers()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Determine Containers' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -160,14 +129,8 @@ pipeline {
         stage('Build Application') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     buildApplication()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Build Application' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -175,14 +138,8 @@ pipeline {
         stage('Build and Push Docker Image') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     buildAndPushDockerImage()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Build and Push Docker Image' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -190,14 +147,8 @@ pipeline {
         stage('Deploy New Instance') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     deployNewInstance()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Deploy New Instance' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -205,14 +156,8 @@ pipeline {
         stage('Health Check') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     performHealthCheck()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Health Check' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -220,14 +165,8 @@ pipeline {
         stage('Switch Traffic and Cleanup') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     switchTrafficAndCleanup()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Switch Traffic and Cleanup' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -236,7 +175,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Deployment failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage '${FAILED_STAGE}' failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/prod/Jenkinsfile
+++ b/jenkins/prod/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                 }
                 withCredentials([file(credentialsId: 'members_prod_config_yml', variable: 'CONFIG_FILE')]) {
                     script {
@@ -87,6 +88,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                 }
                 sh 'java -version'
             }
@@ -96,6 +98,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     env.GIT_CHANGELOG = getChangeLog()
                 }
             }
@@ -105,6 +108,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     backupPostgres()
                 }
             }
@@ -114,6 +118,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     dockerLogin()
                 }
             }
@@ -123,6 +128,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     determineContainers()
                 }
             }
@@ -132,6 +138,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     buildApplication()
                 }
             }
@@ -141,6 +148,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     buildAndPushDockerImage()
                 }
             }
@@ -150,6 +158,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     deployNewInstance()
                 }
             }
@@ -159,6 +168,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     performHealthCheck()
                 }
             }
@@ -168,6 +178,7 @@ pipeline {
             steps {
                 script {
                     env.FAILED_STAGE = env.STAGE_NAME
+                    echo "Setting FAILED_STAGE to ${env.STAGE_NAME}"
                     switchTrafficAndCleanup()
                 }
             }

--- a/jenkins/stage/Jenkinsfile
+++ b/jenkins/stage/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage *${FAILED_STAGE}* failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage **${FAILED_STAGE}** failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/stage/Jenkinsfile
+++ b/jenkins/stage/Jenkinsfile
@@ -17,6 +17,7 @@
  * Ensure the plugin is up-to-date to avoid compatibility issues.
  */
 
+def FAILED_STAGE = ""
 
 pipeline {
     agent any
@@ -28,6 +29,9 @@ pipeline {
     stages {
         stage('Load Environment Variables') {
             steps {
+                script {
+                    FAILED_STAGE = env.STAGE_NAME
+                }
                 withCredentials([file(credentialsId: 'members_stage_config_yml', variable: 'CONFIG_FILE')]) {
                     script {
                         def config = readYaml(file: env.CONFIG_FILE)
@@ -75,39 +79,22 @@ pipeline {
                     }
                 }
             }
-             post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Load Environment Variables' failed.", env.SLACK_COLOR_FAILURE)
-                    }
-                }
-            }
         }
 
         stage('Check Java Version') {
             steps {
-                sh 'java -version'
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Check Java Version' failed.", env.SLACK_COLOR_FAILURE)
-                    }
+                script {
+                    FAILED_STAGE = env.STAGE_NAME
                 }
+                sh 'java -version'
             }
         }
 
         stage('Get Git Change Log') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     env.GIT_CHANGELOG = getChangeLog()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Get Git Change Log' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -115,14 +102,8 @@ pipeline {
         stage('PostgreSQL Backup') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     backupPostgres()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'PostgreSQL Backup' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -130,14 +111,8 @@ pipeline {
         stage('Docker Hub Login') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     dockerLogin()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Docker Hub Login' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -145,14 +120,8 @@ pipeline {
         stage('Determine Containers') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     determineContainers()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Determine Containers' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -160,14 +129,8 @@ pipeline {
         stage('Build Application') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     buildApplication()
-                }
-            }
-             post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Build Application' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -175,14 +138,8 @@ pipeline {
         stage('Build and Push Docker Image') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     buildAndPushDockerImage()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Build and Push Docker Image' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -190,14 +147,8 @@ pipeline {
         stage('Deploy New Instance') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     deployNewInstance()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Deploy New Instance' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -205,14 +156,8 @@ pipeline {
         stage('Health Check') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     performHealthCheck()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Health Check' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -220,14 +165,8 @@ pipeline {
         stage('Switch Traffic and Cleanup') {
             steps {
                 script {
+                    FAILED_STAGE = env.STAGE_NAME
                     switchTrafficAndCleanup()
-                }
-            }
-            post {
-                failure {
-                    script {
-                        sendSlackBuildNotification(":scream_cat: Stage 'Switch Traffic and Cleanup' failed.", env.SLACK_COLOR_FAILURE)
-                    }
                 }
             }
         }
@@ -236,7 +175,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Deployment failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage '${FAILED_STAGE}' failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/stage/Jenkinsfile
+++ b/jenkins/stage/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage '${FAILED_STAGE}' failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage *${FAILED_STAGE}* failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/stage/Jenkinsfile
+++ b/jenkins/stage/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackBuildNotification(":scream_cat: Stage **${FAILED_STAGE}** failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackBuildNotification(":scream_cat: Stage *${FAILED_STAGE}* failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 

--- a/jenkins/stage/Jenkinsfile
+++ b/jenkins/stage/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     stages {
         stage('Load Environment Variables') {
             steps {
-                withCredentials([file(credentialsId: 'platforms_stage_config_yml', variable: 'CONFIG_FILE')]) {
+                withCredentials([file(credentialsId: 'members_stage_config_yml', variable: 'CONFIG_FILE')]) {
                     script {
                         def config = readYaml(file: env.CONFIG_FILE)
 
@@ -75,18 +75,24 @@ pipeline {
                     }
                 }
             }
+             post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Load Environment Variables' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('Check Java Version') {
             steps {
                 sh 'java -version'
             }
-        }
-
-        stage('Slack Notification: Staging Server Testing') {
-            steps {
-                script {
-                    sendSlackNotification(":test_tube: Testing the Staging server...", env.SLACK_COLOR_SUCCESS)
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Check Java Version' failed.", env.SLACK_COLOR_FAILURE)
+                    }
                 }
             }
         }
@@ -97,12 +103,26 @@ pipeline {
                     env.GIT_CHANGELOG = getChangeLog()
                 }
             }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Get Git Change Log' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('PostgreSQL Backup') {
             steps {
                 script {
                     backupPostgres()
+                }
+            }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'PostgreSQL Backup' failed.", env.SLACK_COLOR_FAILURE)
+                    }
                 }
             }
         }
@@ -113,12 +133,26 @@ pipeline {
                     dockerLogin()
                 }
             }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Docker Hub Login' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('Determine Containers') {
             steps {
                 script {
                     determineContainers()
+                }
+            }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Determine Containers' failed.", env.SLACK_COLOR_FAILURE)
+                    }
                 }
             }
         }
@@ -129,12 +163,26 @@ pipeline {
                     buildApplication()
                 }
             }
+             post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Build Application' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('Build and Push Docker Image') {
             steps {
                 script {
                     buildAndPushDockerImage()
+                }
+            }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Build and Push Docker Image' failed.", env.SLACK_COLOR_FAILURE)
+                    }
                 }
             }
         }
@@ -145,6 +193,13 @@ pipeline {
                     deployNewInstance()
                 }
             }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Deploy New Instance' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('Health Check') {
@@ -153,12 +208,26 @@ pipeline {
                     performHealthCheck()
                 }
             }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Health Check' failed.", env.SLACK_COLOR_FAILURE)
+                    }
+                }
+            }
         }
 
         stage('Switch Traffic and Cleanup') {
             steps {
                 script {
                     switchTrafficAndCleanup()
+                }
+            }
+            post {
+                failure {
+                    script {
+                        sendSlackBuildNotification(":scream_cat: Stage 'Switch Traffic and Cleanup' failed.", env.SLACK_COLOR_FAILURE)
+                    }
                 }
             }
         }
@@ -178,25 +247,6 @@ pipeline {
         }
     }
 }
-
-def sendSlackNotification(String message, String color) {
-    def payload = [
-        attachments: [
-            [
-                color: color,
-                text: message.replaceAll('"', '\\"').replaceAll('\n', '\\\\n')
-            ]
-        ]
-    ]
-
-    withEnv(["SLACK_WEBHOOK_URL=${env.SLACK_WEBHOOK_URL}"]) {
-        def payloadJson = groovy.json.JsonOutput.toJson(payload)
-        sh """
-            curl -X POST -H 'Content-type: application/json' --data '${payloadJson}' ${SLACK_WEBHOOK_URL}
-        """
-    }
-}
-
 
 def sendSlackBuildNotification(String message, String color) {
     def jobUrl = "${env.JENKINS_DOMAIN}/job/${env.JOB_NAME}"
@@ -291,7 +341,6 @@ def backupPostgres() {
             docker exec -e PGPASSWORD=${PG_PASSWORD} ${POSTGRESQL_CONTAINER_NAME} sh -c 'pg_dumpall -c -U ${PG_USER} > ${BACKUP_DIR}/${BACKUP_FILE}'
         """
     }
-    sendSlackNotification(":floppy_disk: PostgreSQL backup completed successfully: ${BACKUP_FILE}", env.SLACK_COLOR_SUCCESS)
 }
 
 def dockerLogin() {
@@ -403,7 +452,6 @@ def deployNewInstance() {
             docker ps -a
         """
     }
-    sendSlackNotification(":low_battery: Restarting the Staging server...", env.SLACK_COLOR_SUCCESS)
 }
 
 def performHealthCheck() {
@@ -433,7 +481,6 @@ def performHealthCheck() {
         }
 
         if (System.currentTimeMillis() >= timeout) {
-            sendSlackNotification(":scream_cat: New Staging application did not start successfully within 2.5 minutes.", env.SLACK_COLOR_FAILURE)
             sh "docker stop ${env.DEPLOY_CONTAINER}"
             sh "docker rm ${env.DEPLOY_CONTAINER}"
             error "Health check failed"


### PR DESCRIPTION
## Summary

> #518 

1. 서버 배포시 슬랙 알림을 최소화하고 members와 plus 프로젝트 채널을 구분하고자 했습니다. 이에 웹훅 URL을 두 개 생성해놓았습니다. 
2. 추가로 C-Lab-CoreTeam 슬랙 워크스페이스를 새로 개설하였습니다.

## Tasks
 - 새로운 슬랙 워크스페이스 생성
 - members와 plus 프로젝트의 슬랙 알림 채널을 구분
 - 배포 성공/실패한 경우에만 슬랙에 알림을 전송하도록 변경

## ETC
members prod config 파일은 따로 관리되는 레포에 올렸습니다.

## Screenshot
새로운 슬랙 워크스페이스입니다. 채널이 members, plus로 나눠져 있고, 웹훅 링크도 만들어놓은 상태입니다. 또한 members prod의 경우는 jenkins 관련 config 파일에 members 채널에 연결할 수 있는 링크로 수정해서 환경변수 레포에 올려놨습니다. 
![image](https://github.com/user-attachments/assets/83c3db80-0de6-41fc-a2f8-c32b48bf79b7)



기존의 platforms_prod_config_yml에서 members_prod_config_yml로 수정하였습니다. 또한 실제 yml 파일 내에 새로 만든 워크플레이스의 members 채널에 웹훅을 연결했습니다.
![image](https://github.com/user-attachments/assets/8f85a668-dbab-48ba-825e-861ffea74f15)
