### PR TITLE
fix: 삭제된 게시글로 인해 나의 댓글이 조회되지 않는 문제 수정

### DIFF
--- a/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardPersistenceAdapter.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardPersistenceAdapter.java
@@ -47,7 +47,7 @@ public class BoardPersistenceAdapter implements
 
     @Override
     public Page<Board> findAllByMemberId(String memberId, Pageable pageable) {
-        return boardRepository.findAllByMemberId(memberId, pageable)
+        return boardRepository.findAllByMemberIdAndIsDeletedFalse(memberId, pageable)
                 .map(boardMapper::toDomain);
     }
 

--- a/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardPersistenceAdapter.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardPersistenceAdapter.java
@@ -34,6 +34,13 @@ public class BoardPersistenceAdapter implements
     }
 
     @Override
+    public Board findByIdRegardlessOfDeletion(Long boardId) {
+        return boardRepository.findByIdRegardlessOfDeletion(boardId)
+                .map(boardMapper::toDomain)
+                .orElseThrow(() -> new NotFoundException("[Board] id: " + boardId + "에 해당하는 게시글이 존재하지 않습니다."));
+    }
+
+    @Override
     public Page<Board> findAllByCategory(BoardCategory category, Pageable pageable) {
         return boardRepository.findAllByCategory(category, pageable)
                 .map(boardMapper::toDomain);

--- a/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardRepository.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import page.clab.api.domain.community.board.domain.BoardCategory;
 
@@ -22,6 +23,6 @@ public interface BoardRepository extends JpaRepository<BoardJpaEntity, Long> {
 
     List<BoardJpaEntity> findByMemberId(String memberId);
 
-    @Query(value = "SELECT b FROM BoardJpaEntity b WHERE b.id = ?1", nativeQuery = true)
-    Optional<BoardJpaEntity> findByIdRegardlessOfDeletion(Long boardId);
+    @Query(value = "SELECT b FROM board b WHERE b.id = :boardId", nativeQuery = true)
+    Optional<BoardJpaEntity> findByIdRegardlessOfDeletion(@Param("boardId") Long boardId);
 }

--- a/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardRepository.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardRepository.java
@@ -23,6 +23,6 @@ public interface BoardRepository extends JpaRepository<BoardJpaEntity, Long> {
 
     List<BoardJpaEntity> findByMemberId(String memberId);
 
-    @Query(value = "SELECT b FROM board b WHERE b.id = :boardId", nativeQuery = true)
+    @Query(value = "SELECT * FROM board b WHERE b.id = :boardId", nativeQuery = true)
     Optional<BoardJpaEntity> findByIdRegardlessOfDeletion(@Param("boardId") Long boardId);
 }

--- a/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardRepository.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardRepository.java
@@ -1,13 +1,13 @@
 package page.clab.api.domain.community.board.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import page.clab.api.domain.community.board.domain.BoardCategory;
-
-import java.util.List;
 
 @Repository
 public interface BoardRepository extends JpaRepository<BoardJpaEntity, Long> {
@@ -21,4 +21,7 @@ public interface BoardRepository extends JpaRepository<BoardJpaEntity, Long> {
     Page<BoardJpaEntity> findAllByIsDeletedTrue(Pageable pageable);
 
     List<BoardJpaEntity> findByMemberId(String memberId);
+
+    @Query(value = "SELECT b FROM BoardJpaEntity b WHERE b.id = ?1", nativeQuery = true)
+    Optional<BoardJpaEntity> findByIdRegardlessOfDeletion(Long boardId);
 }

--- a/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardRepository.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Repository
 public interface BoardRepository extends JpaRepository<BoardJpaEntity, Long> {
 
+    @Query("SELECT b FROM BoardJpaEntity b WHERE b.memberId = ?1 AND b.isDeleted = false")
     Page<BoardJpaEntity> findAllByMemberIdAndIsDeletedFalse(String memberId, Pageable pageable);
 
     Page<BoardJpaEntity> findAllByCategory(BoardCategory category, Pageable pageable);

--- a/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardRepository.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Repository
 public interface BoardRepository extends JpaRepository<BoardJpaEntity, Long> {
 
-    Page<BoardJpaEntity> findAllByMemberId(String memberId, Pageable pageable);
+    Page<BoardJpaEntity> findAllByMemberIdAndIsDeletedFalse(String memberId, Pageable pageable);
 
     Page<BoardJpaEntity> findAllByCategory(BoardCategory category, Pageable pageable);
 

--- a/src/main/java/page/clab/api/domain/community/board/application/port/out/RetrieveBoardPort.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/port/out/RetrieveBoardPort.java
@@ -9,6 +9,8 @@ public interface RetrieveBoardPort {
 
     Board findByIdOrThrow(Long boardId);
 
+    Board findByIdRegardlessOfDeletion(Long boardId);
+
     Page<Board> findAll(Pageable pageable);
 
     Page<Board> findAllByCategory(BoardCategory category, Pageable pageable);

--- a/src/main/java/page/clab/api/external/community/board/application/service/ExternalBoardRetrievalService.java
+++ b/src/main/java/page/clab/api/external/community/board/application/service/ExternalBoardRetrievalService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import page.clab.api.domain.community.board.application.dto.shared.BoardCommentInfoDto;
+import page.clab.api.domain.community.board.application.port.out.RetrieveBoardPort;
 import page.clab.api.domain.community.board.application.service.BoardRetrievalService;
 import page.clab.api.domain.community.board.domain.Board;
 import page.clab.api.external.community.board.application.port.ExternalRetrieveBoardUseCase;
@@ -13,6 +14,7 @@ import page.clab.api.external.community.board.application.port.ExternalRetrieveB
 public class ExternalBoardRetrievalService implements ExternalRetrieveBoardUseCase {
 
     private final BoardRetrievalService boardRetrievalService;
+    private final RetrieveBoardPort retrieveBoardPort;
 
     @Transactional(readOnly = true)
     @Override
@@ -23,7 +25,7 @@ public class ExternalBoardRetrievalService implements ExternalRetrieveBoardUseCa
     @Transactional(readOnly = true)
     @Override
     public BoardCommentInfoDto getBoardCommentInfoById(Long boardId) {
-        Board board = boardRetrievalService.findByIdOrThrow(boardId);
+        Board board = retrieveBoardPort.findByIdRegardlessOfDeletion(boardId);
         return BoardCommentInfoDto.create(board);
     }
 }


### PR DESCRIPTION
## Summary

> #524 

마이페이지 내가 쓴 댓글 조회 시 삭제된 게시글의 댓글도 반환하도록 수정했습니다.
내가 쓴 댓글 조회 시 삭제된 게시글일 경우 board 정보를 찾지 못해 NotFoundException이 발생하였습니다.
그 결과 마이페이지 접속이 안 되는 버그가 발생했습니다.

## Tasks

- 마이페이지 내가 쓴 댓글 조회 시 삭제된 게시글의 댓글도 반환하도록 수정

