### PR TITLE
refactor: 화이트리스트 관리 방식 JSON → YAML 전환 및 서브넷 마스크 지원 기능 추가 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ gradle/
 src/main/java/page/clab/api/global/auth/application/DataLoader.java
 src/main/java/page/clab/api/global/auth/application/MemberFactory.java
 src/main/java/page/clab/api/global/config/SecurityProperties.java
-/config/whitelist.json
+/config/whitelist.yml
 
 ### STS ###
 .apt_generated

--- a/src/main/java/page/clab/api/global/auth/application/IpWhitelistValidator.java
+++ b/src/main/java/page/clab/api/global/auth/application/IpWhitelistValidator.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class WhitelistService {
+public class IpWhitelistValidator {
 
     @Value("${security.whitelist.enabled}")
     private boolean whitelistEnabled;

--- a/src/main/java/page/clab/api/global/auth/application/WhitelistService.java
+++ b/src/main/java/page/clab/api/global/auth/application/WhitelistService.java
@@ -1,17 +1,20 @@
 package page.clab.api.global.auth.application;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 @Service
 @Slf4j
@@ -28,17 +31,41 @@ public class WhitelistService {
             return List.of("*");
         }
         try {
-            ObjectMapper mapper = new ObjectMapper();
+            // YAML 파일 읽기/쓰기 옵션 설정
+            DumperOptions options = new DumperOptions();
+            options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+            options.setIndent(2);
+            options.setPrettyFlow(true);
+
+            Yaml yaml = new Yaml(options);
             Path path = Paths.get(whitelistPath);
+
+            // 파일이 존재하지 않을 경우, 기본 YAML 파일 생성
             if (Files.notExists(path)) {
                 Files.createDirectories(path.getParent());
-                Map<String, List<String>> defaultContent = Map.of("allowedIps", List.of("*"));
-                mapper.writeValue(Files.newBufferedWriter(path), defaultContent);
-                log.info("Whitelist IP file created at {}", whitelistPath);
+                Map<String, Map<String, List<String>>> defaultContent = Map.of(
+                        "whitelist", Map.of(
+                                "fixedIps", List.of(""),
+                                "temporaryIps", List.of("*")
+                        )
+                );
+                yaml.dump(defaultContent, Files.newBufferedWriter(path));
+                log.info("Whitelist YAML file created at {}", whitelistPath);
             }
-            Map<String, List<String>> data = mapper.readValue(path.toFile(), new TypeReference<>() {
-            });
-            return data.getOrDefault("allowedIps", List.of("*"));
+
+            // YAML 파일에서 데이터 읽기
+            try (InputStream inputStream = Files.newInputStream(path)) {
+                Map<String, Map<String, List<String>>> data = yaml.load(inputStream);
+                Map<String, List<String>> whitelist = data.getOrDefault("whitelist", Map.of());
+
+                List<String> fixedIps = whitelist.getOrDefault("fixedIps", List.of());
+                List<String> temporaryIps = whitelist.getOrDefault("temporaryIps", List.of());
+
+                return Stream.concat(
+                        fixedIps.stream().filter(Objects::nonNull),
+                        temporaryIps.stream().filter(Objects::nonNull)
+                ).toList();
+            }
         } catch (IOException e) {
             log.error("Failed to load or create IP whitelist from path: {}", whitelistPath, e);
             return List.of("*");

--- a/src/main/java/page/clab/api/global/auth/application/WhitelistService.java
+++ b/src/main/java/page/clab/api/global/auth/application/WhitelistService.java
@@ -1,10 +1,11 @@
 package page.clab.api.global.auth.application;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
+import page.clab.api.global.util.IpAddressUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,6 +18,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 @Service
+@RequiredArgsConstructor
 @Slf4j
 public class WhitelistService {
 
@@ -26,49 +28,76 @@ public class WhitelistService {
     @Value("${security.whitelist.path}")
     private String whitelistPath;
 
-    public List<String> loadWhitelistIps() {
+    private final Yaml yaml;
+
+    /**
+     * 요청된 IP가 화이트리스트에 포함되는지 확인합니다.
+     * @param ipAddress 확인하려는 IP 주소
+     * @return IP가 화이트리스트에 포함되면 true, 그렇지 않으면 false
+     */
+    public boolean isIpWhitelisted(String ipAddress) {
         if (!whitelistEnabled) {
-            return List.of("*");
+            return true;
         }
+
+        List<String> whitelistIps = loadWhitelistIps();
+
+        return whitelistIps.stream()
+                .filter(Objects::nonNull)
+                .anyMatch(ip -> "*".equals(ip) || IpAddressUtil.isIpInRange(ipAddress, ip));
+    }
+
+    /**
+     * 화이트리스트 YAML 파일에서 IP 목록을 로드합니다.
+     * @return 화이트리스트에 포함된 IP 목록
+     */
+    private List<String> loadWhitelistIps() {
         try {
-            // YAML 파일 읽기/쓰기 옵션 설정
-            DumperOptions options = new DumperOptions();
-            options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-            options.setIndent(2);
-            options.setPrettyFlow(true);
-
-            Yaml yaml = new Yaml(options);
             Path path = Paths.get(whitelistPath);
-
-            // 파일이 존재하지 않을 경우, 기본 YAML 파일 생성
             if (Files.notExists(path)) {
-                Files.createDirectories(path.getParent());
-                Map<String, Map<String, List<String>>> defaultContent = Map.of(
-                        "whitelist", Map.of(
-                                "fixedIps", List.of(""),
-                                "temporaryIps", List.of("*")
-                        )
-                );
-                yaml.dump(defaultContent, Files.newBufferedWriter(path));
-                log.info("Whitelist YAML file created at {}", whitelistPath);
+                createDefaultWhitelistFile(path, yaml);
             }
-
-            // YAML 파일에서 데이터 읽기
-            try (InputStream inputStream = Files.newInputStream(path)) {
-                Map<String, Map<String, List<String>>> data = yaml.load(inputStream);
-                Map<String, List<String>> whitelist = data.getOrDefault("whitelist", Map.of());
-
-                List<String> fixedIps = whitelist.getOrDefault("fixedIps", List.of());
-                List<String> temporaryIps = whitelist.getOrDefault("temporaryIps", List.of());
-
-                return Stream.concat(
-                        fixedIps.stream().filter(Objects::nonNull),
-                        temporaryIps.stream().filter(Objects::nonNull)
-                ).toList();
-            }
+            return parseWhitelistFile(yaml, path);
         } catch (IOException e) {
             log.error("Failed to load or create IP whitelist from path: {}", whitelistPath, e);
             return List.of("*");
+        }
+    }
+
+    /**
+     * 기본 화이트리스트 YAML 파일을 생성합니다.
+     * @param path 파일 경로
+     * @param yaml Yaml 객체
+     * @throws IOException 파일 생성 중 오류 발생 시
+     */
+    private void createDefaultWhitelistFile(Path path, Yaml yaml) throws IOException {
+        Files.createDirectories(path.getParent());
+        Map<String, Map<String, List<String>>> defaultContent = Map.of(
+                "whitelist", Map.of(
+                        "fixedIps", List.of(""),
+                        "temporaryIps", List.of("*")
+                )
+        );
+        yaml.dump(defaultContent, Files.newBufferedWriter(path));
+        log.info("Whitelist YAML file created at {}", whitelistPath);
+    }
+
+    /**
+     * YAML 파일을 파싱하여 화이트리스트 IP 목록을 반환합니다.
+     * @param yaml Yaml 객체
+     * @param path YAML 파일 경로
+     * @return 화이트리스트에 포함된 IP 목록
+     * @throws IOException 파일 읽기 중 오류 발생 시
+     */
+    private List<String> parseWhitelistFile(Yaml yaml, Path path) throws IOException {
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            Map<String, Map<String, List<String>>> data = yaml.load(inputStream);
+            Map<String, List<String>> whitelist = data.getOrDefault("whitelist", Map.of());
+
+            List<String> fixedIps = whitelist.getOrDefault("fixedIps", List.of());
+            List<String> temporaryIps = whitelist.getOrDefault("temporaryIps", List.of());
+
+            return Stream.concat(fixedIps.stream(), temporaryIps.stream()).toList();
         }
     }
 }

--- a/src/main/java/page/clab/api/global/auth/filter/CustomBasicAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/CustomBasicAuthenticationFilter.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import page.clab.api.external.auth.blacklistIp.application.port.ExternalRetrieveBlacklistIpUseCase;
 import page.clab.api.external.auth.redisIpAccessMonitor.application.port.ExternalCheckIpBlockedUseCase;
-import page.clab.api.global.auth.application.IpWhitelistValidator;
+import page.clab.api.global.auth.util.IpWhitelistValidator;
 import page.clab.api.global.common.slack.application.SlackService;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
 import page.clab.api.global.util.HttpReqResUtil;

--- a/src/main/java/page/clab/api/global/auth/filter/CustomBasicAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/CustomBasicAuthenticationFilter.java
@@ -23,7 +23,6 @@ import page.clab.api.global.util.WhitelistUtil;
 
 import java.io.IOException;
 import java.util.Base64;
-import java.util.List;
 
 @Slf4j
 public class CustomBasicAuthenticationFilter extends BasicAuthenticationFilter {
@@ -93,8 +92,7 @@ public class CustomBasicAuthenticationFilter extends BasicAuthenticationFilter {
 
     private boolean verifyIpAddressAccess(HttpServletResponse response) throws IOException {
         String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
-        List<String> whitelistIps = whitelistService.loadWhitelistIps();
-        if (!(whitelistIps.contains(clientIpAddress) || whitelistIps.contains("*")) ||
+        if (!whitelistService.isIpWhitelisted(clientIpAddress) ||
                 externalRetrieveBlacklistIpUseCase.existsByIpAddress(clientIpAddress) ||
                 externalCheckIpBlockedUseCase.isIpBlocked(clientIpAddress)
         ) {

--- a/src/main/java/page/clab/api/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/JwtAuthenticationFilter.java
@@ -20,7 +20,7 @@ import page.clab.api.global.common.slack.application.SlackService;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
 import page.clab.api.global.util.HttpReqResUtil;
 import page.clab.api.global.util.ResponseUtil;
-import page.clab.api.global.util.WhitelistUtil;
+import page.clab.api.global.util.WhitelistPathMatcher;
 
 import java.io.IOException;
 
@@ -39,7 +39,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
         HttpServletResponse httpServletResponse = (HttpServletResponse) response;
         String path = httpServletRequest.getRequestURI();
-        if (WhitelistUtil.isWhitelistRequest(path)) {
+        if (WhitelistPathMatcher.isWhitelistRequest(path)) {
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/java/page/clab/api/global/auth/util/IpWhitelistValidator.java
+++ b/src/main/java/page/clab/api/global/auth/util/IpWhitelistValidator.java
@@ -29,6 +29,10 @@ public class IpWhitelistValidator {
 
         List<String> whitelistIps = whitelistFileLoader.loadWhitelistIps();
 
+        if (whitelistIps.isEmpty()) {
+            return false;
+        }
+
         return whitelistIps.stream()
                 .filter(Objects::nonNull)
                 .anyMatch(ip -> "*".equals(ip) || IpAddressUtil.isIpInRange(ipAddress, ip));

--- a/src/main/java/page/clab/api/global/auth/util/IpWhitelistValidator.java
+++ b/src/main/java/page/clab/api/global/auth/util/IpWhitelistValidator.java
@@ -1,4 +1,4 @@
-package page.clab.api.global.auth.application;
+package page.clab.api.global.auth.util;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/page/clab/api/global/auth/util/IpWhitelistValidator.java
+++ b/src/main/java/page/clab/api/global/auth/util/IpWhitelistValidator.java
@@ -1,38 +1,21 @@
 package page.clab.api.global.auth.util;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.util.CollectionUtils;
-import org.yaml.snakeyaml.Yaml;
+import org.springframework.stereotype.Component;
 import page.clab.api.global.util.IpAddressUtil;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Stream;
 
-@Service
+@Component
 @RequiredArgsConstructor
-@Slf4j
 public class IpWhitelistValidator {
 
     @Value("${security.whitelist.enabled}")
     private boolean whitelistEnabled;
 
-    @Value("${security.whitelist.path}")
-    private String whitelistPath;
-
-    private final Yaml yaml;
-    private final Lock fileLock = new ReentrantLock();
+    private final WhitelistFileLoader whitelistFileLoader;
 
     /**
      * 요청된 IP가 화이트리스트에 포함되는지 확인합니다.
@@ -44,78 +27,10 @@ public class IpWhitelistValidator {
             return true;
         }
 
-        List<String> whitelistIps = loadWhitelistIps();
+        List<String> whitelistIps = whitelistFileLoader.loadWhitelistIps();
 
         return whitelistIps.stream()
                 .filter(Objects::nonNull)
                 .anyMatch(ip -> "*".equals(ip) || IpAddressUtil.isIpInRange(ipAddress, ip));
-    }
-
-    /**
-     * 화이트리스트 YAML 파일에서 IP 목록을 로드합니다.
-     * @return 화이트리스트에 포함된 IP 목록
-     */
-    private List<String> loadWhitelistIps() {
-        fileLock.lock();
-        try {
-            Path path = Paths.get(whitelistPath);
-
-            if (Files.notExists(path)) {
-                createDefaultWhitelistFile(path, yaml);
-            }
-
-            return parseWhitelistFile(yaml, path);
-        } catch (IOException e) {
-            log.error("Failed to load or create IP whitelist from path: {}", whitelistPath, e);
-            return List.of("*");
-        } finally {
-            fileLock.unlock();
-        }
-    }
-
-    /**
-     * 기본 화이트리스트 YAML 파일을 생성합니다.
-     * @param path 파일 경로
-     * @param yaml Yaml 객체
-     * @throws IOException 파일 생성 중 오류 발생 시
-     */
-    private void createDefaultWhitelistFile(Path path, Yaml yaml) throws IOException {
-        Files.createDirectories(path.getParent());
-        Map<String, Map<String, List<String>>> defaultContent = Map.of(
-                "whitelist", Map.of(
-                        "fixedIps", List.of(""),
-                        "temporaryIps", List.of("*")
-                )
-        );
-        yaml.dump(defaultContent, Files.newBufferedWriter(path));
-        log.info("Whitelist YAML file created at {}", whitelistPath);
-    }
-
-    /**
-     * YAML 파일을 파싱하여 화이트리스트 IP 목록을 반환합니다.
-     * @param yaml Yaml 객체
-     * @param path YAML 파일 경로
-     * @return 화이트리스트에 포함된 IP 목록
-     * @throws IOException 파일 읽기 중 오류 발생 시
-     */
-    private List<String> parseWhitelistFile(Yaml yaml, Path path) throws IOException {
-        try (InputStream inputStream = Files.newInputStream(path)) {
-            Map<String, Map<String, List<String>>> data = yaml.load(inputStream);
-
-            if (CollectionUtils.isEmpty(data)) {
-                log.warn("YAML file is empty or invalid");
-                return List.of("*");
-            }
-
-            Map<String, List<String>> whitelist = data.getOrDefault("whitelist", Map.of());
-
-            List<String> fixedIps = whitelist.getOrDefault("fixedIps", List.of());
-            List<String> temporaryIps = whitelist.getOrDefault("temporaryIps", List.of());
-
-            return Stream.concat(fixedIps.stream(), temporaryIps.stream()).toList();
-        } catch (Exception e) {
-            log.error("Failed to parse IP whitelist", e);
-            return List.of("*");
-        }
     }
 }

--- a/src/main/java/page/clab/api/global/auth/util/WhitelistFileLoader.java
+++ b/src/main/java/page/clab/api/global/auth/util/WhitelistFileLoader.java
@@ -1,0 +1,99 @@
+package page.clab.api.global.auth.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WhitelistFileLoader {
+
+    @Value("${security.whitelist.path}")
+    private String whitelistPath;
+
+    private final Yaml yaml;
+    private final Lock fileLock = new ReentrantLock();
+
+    /**
+     * 화이트리스트 YAML 파일에서 IP 목록을 로드합니다.
+     * @return 화이트리스트에 포함된 IP 목록
+     */
+    public List<String> loadWhitelistIps() {
+        fileLock.lock();
+        try {
+            Path path = Paths.get(whitelistPath);
+
+            if (Files.notExists(path)) {
+                createDefaultWhitelistFile(path, yaml);
+            }
+
+            return parseWhitelistFile(yaml, path);
+        } catch (IOException e) {
+            log.error("Failed to load or create IP whitelist from path: {}", whitelistPath, e);
+            return List.of("*");
+        } finally {
+            fileLock.unlock();
+        }
+    }
+
+    /**
+     * 기본 화이트리스트 YAML 파일을 생성합니다.
+     * @param path 파일 경로
+     * @param yaml Yaml 객체
+     * @throws IOException 파일 생성 중 오류 발생 시
+     */
+    private void createDefaultWhitelistFile(Path path, Yaml yaml) throws IOException {
+        Files.createDirectories(path.getParent());
+        Map<String, Map<String, List<String>>> defaultContent = Map.of(
+                "whitelist", Map.of(
+                        "fixedIps", List.of(""),
+                        "temporaryIps", List.of("*")
+                )
+        );
+        yaml.dump(defaultContent, Files.newBufferedWriter(path));
+        log.info("Whitelist YAML file created at {}", whitelistPath);
+    }
+
+    /**
+     * YAML 파일을 파싱하여 화이트리스트 IP 목록을 반환합니다.
+     * @param yaml Yaml 객체
+     * @param path YAML 파일 경로
+     * @return 화이트리스트에 포함된 IP 목록
+     * @throws IOException 파일 읽기 중 오류 발생 시
+     */
+    private List<String> parseWhitelistFile(Yaml yaml, Path path) throws IOException {
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            Map<String, Map<String, List<String>>> data = yaml.load(inputStream);
+
+            if (CollectionUtils.isEmpty(data)) {
+                log.warn("YAML file is empty or invalid");
+                return List.of("*");
+            }
+
+            Map<String, List<String>> whitelist = data.getOrDefault("whitelist", Map.of());
+
+            List<String> fixedIps = whitelist.getOrDefault("fixedIps", List.of());
+            List<String> temporaryIps = whitelist.getOrDefault("temporaryIps", List.of());
+
+            return Stream.concat(fixedIps.stream(), temporaryIps.stream()).toList();
+        } catch (Exception e) {
+            log.error("Failed to parse IP whitelist", e);
+            return List.of("*");
+        }
+    }
+}

--- a/src/main/java/page/clab/api/global/auth/util/WhitelistFileLoader.java
+++ b/src/main/java/page/clab/api/global/auth/util/WhitelistFileLoader.java
@@ -44,7 +44,7 @@ public class WhitelistFileLoader {
 
             return parseWhitelistFile(yaml, path);
         } catch (IOException e) {
-            log.error("Failed to load or create IP whitelist from path: {}", whitelistPath, e);
+            log.error("Failed to load or create IP whitelist", e);
             return List.of("*");
         } finally {
             fileLock.unlock();

--- a/src/main/java/page/clab/api/global/auth/util/WhitelistFileLoader.java
+++ b/src/main/java/page/clab/api/global/auth/util/WhitelistFileLoader.java
@@ -90,7 +90,10 @@ public class WhitelistFileLoader {
             List<String> fixedIps = whitelist.getOrDefault("fixedIps", List.of());
             List<String> temporaryIps = whitelist.getOrDefault("temporaryIps", List.of());
 
-            return Stream.concat(fixedIps.stream(), temporaryIps.stream()).toList();
+            return Stream.concat(
+                    fixedIps != null ? fixedIps.stream() : Stream.empty(),
+                    temporaryIps != null ? temporaryIps.stream() : Stream.empty()
+            ).toList();
         } catch (Exception e) {
             log.error("Failed to parse IP whitelist", e);
             return List.of();

--- a/src/main/java/page/clab/api/global/auth/util/WhitelistFileLoader.java
+++ b/src/main/java/page/clab/api/global/auth/util/WhitelistFileLoader.java
@@ -45,7 +45,7 @@ public class WhitelistFileLoader {
             return parseWhitelistFile(yaml, path);
         } catch (IOException e) {
             log.error("Failed to load or create IP whitelist", e);
-            return List.of("*");
+            return List.of();
         } finally {
             fileLock.unlock();
         }
@@ -82,7 +82,7 @@ public class WhitelistFileLoader {
 
             if (CollectionUtils.isEmpty(data)) {
                 log.warn("YAML file is empty or invalid");
-                return List.of("*");
+                return List.of();
             }
 
             Map<String, List<String>> whitelist = data.getOrDefault("whitelist", Map.of());
@@ -93,7 +93,7 @@ public class WhitelistFileLoader {
             return Stream.concat(fixedIps.stream(), temporaryIps.stream()).toList();
         } catch (Exception e) {
             log.error("Failed to parse IP whitelist", e);
-            return List.of("*");
+            return List.of();
         }
     }
 }

--- a/src/main/java/page/clab/api/global/config/SecurityConfig.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConfig.java
@@ -27,12 +27,12 @@ import page.clab.api.external.auth.blacklistIp.application.port.ExternalRetrieve
 import page.clab.api.external.auth.redisIpAccessMonitor.application.port.ExternalCheckIpBlockedUseCase;
 import page.clab.api.external.auth.redisIpAccessMonitor.application.port.ExternalRegisterIpAccessMonitorUseCase;
 import page.clab.api.external.auth.redisToken.application.port.ExternalManageRedisTokenUseCase;
-import page.clab.api.global.auth.application.IpWhitelistValidator;
 import page.clab.api.global.auth.filter.CustomBasicAuthenticationFilter;
 import page.clab.api.global.auth.filter.InvalidEndpointAccessFilter;
 import page.clab.api.global.auth.filter.IpAuthenticationFilter;
 import page.clab.api.global.auth.filter.JwtAuthenticationFilter;
 import page.clab.api.global.auth.jwt.JwtTokenProvider;
+import page.clab.api.global.auth.util.IpWhitelistValidator;
 import page.clab.api.global.common.file.application.FileService;
 import page.clab.api.global.common.slack.application.SlackService;
 import page.clab.api.global.filter.IPinfoSpringFilter;

--- a/src/main/java/page/clab/api/global/config/SecurityConfig.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConfig.java
@@ -27,7 +27,7 @@ import page.clab.api.external.auth.blacklistIp.application.port.ExternalRetrieve
 import page.clab.api.external.auth.redisIpAccessMonitor.application.port.ExternalCheckIpBlockedUseCase;
 import page.clab.api.external.auth.redisIpAccessMonitor.application.port.ExternalRegisterIpAccessMonitorUseCase;
 import page.clab.api.external.auth.redisToken.application.port.ExternalManageRedisTokenUseCase;
-import page.clab.api.global.auth.application.WhitelistService;
+import page.clab.api.global.auth.application.IpWhitelistValidator;
 import page.clab.api.global.auth.filter.CustomBasicAuthenticationFilter;
 import page.clab.api.global.auth.filter.InvalidEndpointAccessFilter;
 import page.clab.api.global.auth.filter.IpAuthenticationFilter;
@@ -55,7 +55,7 @@ public class SecurityConfig {
     private final ExternalRegisterBlacklistIpUseCase externalRegisterBlacklistIpUseCase;
     private final ExternalRetrieveBlacklistIpUseCase externalRetrieveBlacklistIpUseCase;
     private final SlackService slackService;
-    private final WhitelistService whitelistService;
+    private final IpWhitelistValidator ipWhitelistValidator;
     private final WhitelistAccountProperties whitelistAccountProperties;
     private final WhitelistPatternsProperties whitelistPatternsProperties;
     private final IPInfoConfig ipInfoConfig;
@@ -96,7 +96,7 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .addFilterBefore(
-                        new CustomBasicAuthenticationFilter(authenticationManager, whitelistService, slackService, externalCheckIpBlockedUseCase, externalRetrieveBlacklistIpUseCase),
+                        new CustomBasicAuthenticationFilter(authenticationManager, ipWhitelistValidator, slackService, externalCheckIpBlockedUseCase, externalRetrieveBlacklistIpUseCase),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .addFilterBefore(

--- a/src/main/java/page/clab/api/global/config/YamlConfig.java
+++ b/src/main/java/page/clab/api/global/config/YamlConfig.java
@@ -1,0 +1,19 @@
+package page.clab.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+@Configuration
+public class YamlConfig {
+
+    @Bean
+    public Yaml yamlParser() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setIndent(2);
+        options.setPrettyFlow(true);
+        return new Yaml(options);
+    }
+}

--- a/src/main/java/page/clab/api/global/util/IpAddressUtil.java
+++ b/src/main/java/page/clab/api/global/util/IpAddressUtil.java
@@ -1,0 +1,21 @@
+package page.clab.api.global.util;
+
+import org.springframework.security.web.util.matcher.IpAddressMatcher;
+
+public class IpAddressUtil {
+
+    /**
+     * 주어진 IP가 특정 서브넷이나 IP 주소와 일치하는지 확인합니다.
+     * @param ipAddress 확인하려는 대상 IP 주소
+     * @param ipOrCidr 서브넷 마스크를 포함한 IP 주소 (예: 192.168.1.0/24 또는 단일 IP 주소)
+     * @return 주어진 IP가 서브넷 내에 있거나 IP 주소와 일치하면 true, 그렇지 않으면 false
+     */
+    public static boolean isIpInRange(String ipAddress, String ipOrCidr) {
+        try {
+            IpAddressMatcher ipAddressMatcher = new IpAddressMatcher(ipOrCidr);
+            return ipAddressMatcher.matches(ipAddress);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/page/clab/api/global/util/WhitelistPathMatcher.java
+++ b/src/main/java/page/clab/api/global/util/WhitelistPathMatcher.java
@@ -7,7 +7,7 @@ import page.clab.api.global.config.WhitelistPatternsProperties;
 import java.util.regex.Pattern;
 
 @Component
-public class WhitelistUtil implements InitializingBean {
+public class WhitelistPathMatcher implements InitializingBean {
 
     private static String[] swaggerPatterns;
     private static String[] actuatorPatterns;
@@ -15,7 +15,7 @@ public class WhitelistUtil implements InitializingBean {
 
     private final WhitelistPatternsProperties whitelistPatternsProperties;
 
-    public WhitelistUtil(WhitelistPatternsProperties whitelistPatternsProperties) {
+    public WhitelistPathMatcher(WhitelistPatternsProperties whitelistPatternsProperties) {
         this.whitelistPatternsProperties = whitelistPatternsProperties;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,7 +106,7 @@ security:
   # Whitelist configuration
   whitelist:
     enabled: true
-    path: ${user.dir}/config/whitelist.json # Path to the whitelist file
+    path: ${user.dir}/config/whitelist.yml # Path to the whitelist file
     patterns:
       actuator: # Default Actuator paths
         - /actuator


### PR DESCRIPTION
## Summary

> #527 

이트리스트 관리 방식을 JSON에서 YAML로 전환하고, 서브넷 마스크를 지원하는 기능을 추가했습니다. 이를 통해 IP 관리의 유연성을 높이고, YAML의 가독성과 유지보수성을 활용할 수 있도록 개선하였습니다.

## Tasks

- JSON 파일을 YAML 파일로 변환하여 관리 방식을 개선하였습니다.
- 서브넷 마스크를 지원하여 동일 네트워크 내의 IP 범위를 보다 효율적으로 관리할 수 있도록 기능을 추가하였습니다.
- 파일 접근 시 발생할 수 있는 경합 조건(Race Condition) 문제를 해결하기 위해 Lock을 적용하여 동기화 처리하였습니다.

## Screenshot
생성된 `whitelist.yml`
![image](https://github.com/user-attachments/assets/385133e4-aacd-4871-a1bd-1d9f0877aa92)
