### PR TITLE
refactor: 활동 관련 2차 QA에 따른 활동 멤버 관련 로직 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
@@ -76,12 +76,12 @@ public class ActivityGroupAdminController {
         return ApiResponse.success(updatedStatusDto);
     }
 
-    @Operation(summary = "[A] 활동 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "[A] 활동 삭제", description = "ROLE_USER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{activityGroupId}")
     public ApiResponse<Long> deleteActivityGroup(
             @PathVariable(name = "activityGroupId") Long activityGroupId
-    ) {
+    ) throws PermissionDeniedException {
         Long id = activityGroupAdminService.deleteActivityGroup(activityGroupId);
         return ApiResponse.success(id);
     }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -34,6 +34,7 @@ import page.clab.api.global.common.dto.PagedResponseDto;
 import page.clab.api.global.exception.NotFoundException;
 import page.clab.api.global.exception.PermissionDeniedException;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -157,7 +158,9 @@ public class ActivityGroupAdminService {
                     String applyReason = memberIdToApplyReasonMap.getOrDefault(groupMember.getMemberId(), "");
                     Member member = externalRetrieveMemberUseCase.findByIdOrThrow(groupMember.getMemberId());
                     return ActivityGroupMemberWithApplyReasonResponseDto.create(member, groupMember, applyReason);
-                }).toList();
+                })
+                .sorted(Comparator.comparing(ActivityGroupMemberWithApplyReasonResponseDto::getStatus))
+                .toList();
 
         return new PagedResponseDto<>(new PageImpl<>(groupMembersWithApplyReason, pageable, groupMembers.getTotalElements()));
     }
@@ -204,7 +207,7 @@ public class ActivityGroupAdminService {
 
     public boolean isMemberGroupLeaderRole(ActivityGroup activityGroup, Member member) {
         GroupMember groupMember = activityGroupMemberService.getGroupMemberByActivityGroupAndMemberOrThrow(activityGroup, member.getId());
-        return groupMember.isLeader() && member.isAdminRole();
+        return groupMember.isLeader() || member.isAdminRole();
     }
 
     public boolean isMemberGroupLeaderRole(Long activityGroupId, String memberId) {
@@ -212,7 +215,7 @@ public class ActivityGroupAdminService {
         Member member = externalRetrieveMemberUseCase.findByIdOrThrow(memberId);
         try{
             GroupMember groupMember = activityGroupMemberService.getGroupMemberByActivityGroupAndMemberOrThrow(activityGroup, member.getId());
-            return groupMember.isLeader() && member.isAdminRole();
+            return groupMember.isLeader() || member.isAdminRole();
         } catch (NotFoundException e) {
          return false;
         }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -96,11 +96,16 @@ public class ActivityGroupAdminService {
     }
 
     @Transactional
-    public Long deleteActivityGroup(Long activityGroupId) {
+    public Long deleteActivityGroup(Long activityGroupId) throws PermissionDeniedException {
         ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);
         List<GroupMember> groupMembers = activityGroupMemberService.getGroupMemberByActivityGroupId(activityGroupId);
         List<GroupSchedule> groupSchedules = groupScheduleRepository.findAllByActivityGroupIdOrderByIdDesc(activityGroupId);
         List<GroupMember> groupLeaders = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroupId, ActivityGroupRole.LEADER);
+
+        Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
+        if (!isMemberGroupLeaderRole(activityGroup, currentMember)) {
+            throw new PermissionDeniedException("해당 활동을 삭제할 권한이 없습니다.");
+        }
 
         activityGroupMemberService.deleteAll(groupMembers);
         groupScheduleRepository.deleteAll(groupSchedules);

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -224,7 +224,7 @@ public class ActivityGroupAdminService {
     private void validateLeaderRoleChange(ActivityGroup activityGroup, GroupMember groupMember) {
         List<GroupMember> groupMembers = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroup.getId(), ActivityGroupRole.LEADER);
         if(groupMembers.size() == 1 && groupMember.isLeader()) {
-            throw new SingleLeaderModificationException("그룹에 한 명의 리더만 존재할 때는 리더의 역할을 변경할 수 없습니다.");
+            throw new SingleLeaderModificationException("그룹에는 최소 한 명의 리더가 있어야 하므로, 리더의 역할을 변경할 수 없습니다.");
         }
     }
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/domain/GroupMemberStatus.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/domain/GroupMemberStatus.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum GroupMemberStatus {
 
-    REJECTED("REJECTED", "거절"),
+    WAITING("WAITING", "승인 대기"),
     ACCEPTED("ACCEPTED", "수락"),
-    WAITING("WAITING", "승인 대기");
+    REJECTED("REJECTED", "거절");
 
     private final String key;
     private final String description;

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/exception/SingleLeaderModificationException.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/exception/SingleLeaderModificationException.java
@@ -1,0 +1,8 @@
+package page.clab.api.domain.activity.activitygroup.exception;
+
+public class SingleLeaderModificationException extends RuntimeException{
+
+    public SingleLeaderModificationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
@@ -42,6 +42,7 @@ import page.clab.api.domain.activity.activitygroup.exception.InvalidParentBoardE
 import page.clab.api.domain.activity.activitygroup.exception.InvalidRoleException;
 import page.clab.api.domain.activity.activitygroup.exception.LeaderStatusChangeNotAllowedException;
 import page.clab.api.domain.activity.activitygroup.exception.MemberNotPartOfActivityException;
+import page.clab.api.domain.activity.activitygroup.exception.SingleLeaderModificationException;
 import page.clab.api.domain.activity.review.application.exception.AlreadyReviewedException;
 import page.clab.api.domain.auth.login.application.exception.LoginFailedException;
 import page.clab.api.domain.auth.login.application.exception.MemberLockedException;
@@ -191,6 +192,7 @@ public class GlobalExceptionHandler {
             ActivityGroupNotProgressingException.class,
             AlreadySubmittedThisWeekAssignmentException.class,
             LeaderStatusChangeNotAllowedException.class,
+            SingleLeaderModificationException.class,
             AlreadyAppliedException.class,
             DuplicateReportException.class,
             DuplicateAttendanceException.class,


### PR DESCRIPTION
## Summary

> #532 

활동 도메인 2차 QA에 따른 활동 멤버 관련 로직을 수정했습니다.

## Tasks

- 활동 멤버 직책 수정 시 리더가 1명 남은 경우 멤버로 변경할 수 없도록 제약
- 활동 그룹 참여자 정렬을 ACCEPTED, WAITING, REJECT 순으로 수정
- 스터디 삭제 권한을 super, admin, leader로 수정

## ETC


## Screenshot

- 리더가 **한 명**일 때, **리더**의 직책을 **멤버**로 바꾸려고 시도했을 때
![스크린샷 2024-09-07 163402](https://github.com/user-attachments/assets/4c0322b6-2f94-45d4-a448-1c243373476d)

- 활동 그룹 참여자 정렬
```
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 7,
    "take": 7,
    "items": [
      {
        "memberId": "202500004",
        "memberName": "김채원",
        "role": "NONE",
        "status": "WAITING",
        "applyReason": "백엔드에 관심이 있어서"
      },
      {
        "memberId": "202014941",
        "memberName": "송재훈",
        "role": "LEADER",
        "status": "ACCEPTED",
        "applyReason": ""
      },
      {
        "memberId": "202500001",
        "memberName": "설윤",
        "role": "MEMBER",
        "status": "ACCEPTED",
        "applyReason": "백엔드에 관심이 있어서"
      },
      {
        "memberId": "202500002",
        "memberName": "해원",
        "role": "MEMBER",
        "status": "ACCEPTED",
        "applyReason": "백엔드에 관심이 있어서"
      },
      {
        "memberId": "202500005",
        "memberName": "사쿠라",
        "role": "MEMBER",
        "status": "ACCEPTED",
        "applyReason": "백엔드에 관심이 있어서"
      },
      {
        "memberId": "202500007",
        "memberName": "사쿠라",
        "role": "MEMBER",
        "status": "ACCEPTED",
        "applyReason": "백엔드에 관심이 있어서"
      },
      {
        "memberId": "202500006",
        "memberName": "사쿠라",
        "role": "NONE",
        "status": "REJECTED",
        "applyReason": "백엔드에 관심이 있어서"
      }
    ]
  }
}
```

- `Leader`나 `Admin`이 아닌 활동 그룹 멤버가 활동 삭제를 시도했을 때
![스크린샷 2024-09-07 173354](https://github.com/user-attachments/assets/315ea52d-c2dc-4acd-8fbd-ba4fa830df14)
