### PR TITLE
refactor: 활동 관련 2차 QA에 따른 파일 업로드 로직 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
@@ -231,9 +231,9 @@ public class ActivityGroupBoardService {
         }));
     }
 
-    private ActivityGroupBoard getActivityGroupBoardByIdOrThrow(Long activityGroupBoardId) {
+    public ActivityGroupBoard getActivityGroupBoardByIdOrThrow(Long activityGroupBoardId) {
         return activityGroupBoardRepository.findById(activityGroupBoardId)
-                .orElseThrow(() -> new NotFoundException("해당 게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("해당 활동 그룹 게시글을 찾을 수 없습니다."));
     }
 
     private List<ActivityGroupBoard> getChildBoards(Long activityGroupBoardId) {

--- a/src/main/java/page/clab/api/global/common/file/api/FileController.java
+++ b/src/main/java/page/clab/api/global/common/file/api/FileController.java
@@ -133,14 +133,14 @@ public class FileController {
     @Operation(summary = "[U] 활동 그룹 제출 파일 업로드", description = "ROLE_USER 이상의 권한이 필요함 <br> 그룹원이 SUBMIT 게시판에 올릴 파일을 업로드할 때 사용하는 API 입니다." +
             "<br> activityGroupBoardId는 ASSIGNMENT 게시판의 id를 입력하도록 합니다.")
     @PreAuthorize("hasRole('USER')")
-    @PostMapping(value = "/submits/{activityGroupId}/{activityGroupBoardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/submits/{activityGroupId}/{parentBoardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<UploadedFileResponseDto>> submitUpload(
             @PathVariable(name = "activityGroupId") Long activityGroupId,
-            @PathVariable(name = "activityGroupBoardId") Long activityGroupBoardId,
+            @PathVariable(name = "parentBoardId") Long parentBoardId,
             @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles,
             @RequestParam(name = "storagePeriod") long storagePeriod
     ) throws PermissionDeniedException, IOException, NotFoundException {
-        String path = fileService.buildPath("submits", activityGroupId, activityGroupBoardId);
+        String path = fileService.buildPath("submits", activityGroupId, parentBoardId);
         List<UploadedFileResponseDto> responseDtos = fileService.saveFiles(multipartFiles, path, storagePeriod);
         return ApiResponse.success(responseDtos);
     }

--- a/src/main/java/page/clab/api/global/common/file/api/FileController.java
+++ b/src/main/java/page/clab/api/global/common/file/api/FileController.java
@@ -91,7 +91,20 @@ public class FileController {
         return ApiResponse.success(responseDtos);
     }
 
-    @Operation(summary = "[U] 주차별 활동 파일 업로드", description = "ROLE_USER 이상의 권한이 필요함")
+    @Operation(summary = "[U] 활동그룹 공지사항 파일 업로드", description = "ROLE_USER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('USER')")
+    @PostMapping(value = "/notices/{activityGroupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<List<UploadedFileResponseDto>> noticeUpload(
+            @PathVariable(name = "activityGroupId") Long activityGroupId,
+            @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles,
+            @RequestParam(name = "storagePeriod") long storagePeriod
+    ) throws PermissionDeniedException, IOException {
+        String path = fileService.buildPath("notices", activityGroupId);
+        List<UploadedFileResponseDto> responseDtos = fileService.saveFiles(multipartFiles, path, storagePeriod);
+        return ApiResponse.success(responseDtos);
+    }
+
+    @Operation(summary = "[U] 활동그룹 주차별 활동 파일 업로드", description = "ROLE_USER 이상의 권한이 필요함")
     @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "/weekly-activities/{activityGroupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<UploadedFileResponseDto>> weeklyActivityUpload(
@@ -104,16 +117,30 @@ public class FileController {
         return ApiResponse.success(responseDtos);
     }
 
-    @Operation(summary = "[U] 활동 그룹 과제 업로드", description = "ROLE_USER 이상의 권한이 필요함")
+    @Operation(summary = "[U] 활동 그룹 과제 양식 업로드", description = "ROLE_USER 이상의 권한이 필요함 <br> 그룹장이 ASSIGNMENT 게시판에 올릴 파일을 업로드할 때 사용하는 API 입니다.")
     @PreAuthorize("hasRole('USER')")
-    @PostMapping(value = "/assignment/{activityGroupId}/{activityGroupBoardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/assignments/{activityGroupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<UploadedFileResponseDto>> assignmentUpload(
+            @PathVariable(name = "activityGroupId") Long activityGroupId,
+            @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles,
+            @RequestParam(name = "storagePeriod") long storagePeriod
+    ) throws PermissionDeniedException, IOException, NotFoundException {
+        String path = fileService.buildPath("assignments", activityGroupId);
+        List<UploadedFileResponseDto> responseDtos = fileService.saveFiles(multipartFiles, path, storagePeriod);
+        return ApiResponse.success(responseDtos);
+    }
+
+    @Operation(summary = "[U] 활동 그룹 제출 파일 업로드", description = "ROLE_USER 이상의 권한이 필요함 <br> 그룹원이 SUBMIT 게시판에 올릴 파일을 업로드할 때 사용하는 API 입니다." +
+            "<br> activityGroupBoardId는 ASSIGNMENT 게시판의 id를 입력하도록 합니다.")
+    @PreAuthorize("hasRole('USER')")
+    @PostMapping(value = "/submits/{activityGroupId}/{activityGroupBoardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<List<UploadedFileResponseDto>> submitUpload(
             @PathVariable(name = "activityGroupId") Long activityGroupId,
             @PathVariable(name = "activityGroupBoardId") Long activityGroupBoardId,
             @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles,
             @RequestParam(name = "storagePeriod") long storagePeriod
     ) throws PermissionDeniedException, IOException, NotFoundException {
-        String path = fileService.buildPath("assignments", activityGroupId, activityGroupBoardId);
+        String path = fileService.buildPath("submits", activityGroupId, activityGroupBoardId);
         List<UploadedFileResponseDto> responseDtos = fileService.saveFiles(multipartFiles, path, storagePeriod);
         return ApiResponse.success(responseDtos);
     }

--- a/src/main/java/page/clab/api/global/common/file/application/FileHandler.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileHandler.java
@@ -73,13 +73,7 @@ public class FileHandler {
             if (ImageUtil.isImageFile(multipartFile)) {
                 BufferedImage originalImage = ImageUtil.adjustImageDirection(multipartFile);
                 ImageIO.write(originalImage, Objects.requireNonNull(extension), file);
-                if (compressibleImageExtensions.contains(extension.toLowerCase())) {
-                    try {
-                        ImageUtil.compressImage(filePath, savePath, imageQuality);
-                    } catch (ImageCompressionException e) {
-                        log.warn("이미지 압축 중 오류가 발생했습니다. 압축 없이 저장합니다: {}", e.getMessage());
-                    }
-                }
+                compressImageIfPossible(extension, savePath);
             } else {
                 multipartFile.transferTo(file);
             }
@@ -89,6 +83,16 @@ public class FileHandler {
 
         FileUtil.setFilePermissions(file, savePath, filePath);
         return savePath;
+    }
+
+    private void compressImageIfPossible(String extension, String savePath) {
+        if (compressibleImageExtensions.contains(extension.toLowerCase())) {
+            try {
+                ImageUtil.compressImage(filePath, savePath, imageQuality);
+            } catch (ImageCompressionException e) {
+                log.warn("이미지 압축 중 오류가 발생했습니다. 압축 없이 저장합니다: {}", e.getMessage());
+            }
+        }
     }
 
     public void deleteFile(String savedPath) {

--- a/src/main/java/page/clab/api/global/common/file/application/FileHandler.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileHandler.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import page.clab.api.global.exception.ImageCompressionException;
 import page.clab.api.global.util.FileUtil;
 import page.clab.api.global.util.ImageUtil;
 import page.clab.api.global.util.LogSanitizerUtil;
@@ -73,13 +74,17 @@ public class FileHandler {
                 BufferedImage originalImage = ImageUtil.adjustImageDirection(multipartFile);
                 ImageIO.write(originalImage, Objects.requireNonNull(extension), file);
                 if (compressibleImageExtensions.contains(extension.toLowerCase())) {
-                    ImageUtil.compressImage(filePath, savePath, imageQuality);
+                    try {
+                        ImageUtil.compressImage(filePath, savePath, imageQuality);
+                    } catch (ImageCompressionException e) {
+                        log.warn("이미지 압축 중 오류가 발생했습니다. 압축 없이 저장합니다: {}", e.getMessage());
+                    }
                 }
             } else {
                 multipartFile.transferTo(file);
             }
         } catch (Exception e) {
-            throw new IOException("이미지의 뱡향을 조정하는 데 오류가 발생했습니다.", e);
+            throw new IOException("이미지의 최적화 과정에서 오류가 발생했습니다.", e);
         }
 
         FileUtil.setFilePermissions(file, savePath, filePath);

--- a/src/main/java/page/clab/api/global/common/file/application/FileService.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import page.clab.api.domain.activity.activitygroup.application.ActivityGroupAdminService;
 import page.clab.api.domain.activity.activitygroup.application.ActivityGroupBoardService;
-import page.clab.api.domain.activity.activitygroup.dao.ActivityGroupBoardRepository;
 import page.clab.api.domain.activity.activitygroup.dao.ActivityGroupRepository;
 import page.clab.api.domain.activity.activitygroup.dao.GroupMemberRepository;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupBoard;
@@ -40,7 +39,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 @Service
@@ -53,7 +51,6 @@ public class FileService {
     private final ActivityGroupBoardService activityGroupBoardService;
     private final ActivityGroupRepository activityGroupRepository;
     private final GroupMemberRepository groupMemberRepository;
-    private final ActivityGroupBoardRepository activityGroupBoardRepository;
     private final ExternalRetrieveMemberUseCase externalRetrieveMemberUseCase;
     private final ExternalRetrieveCloudUsageByMemberIdUseCase externalRetrieveCloudUsageByMemberIdUseCase;
 

--- a/src/main/java/page/clab/api/global/common/file/application/FileService.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileService.java
@@ -14,6 +14,7 @@ import page.clab.api.domain.activity.activitygroup.application.ActivityGroupAdmi
 import page.clab.api.domain.activity.activitygroup.dao.ActivityGroupBoardRepository;
 import page.clab.api.domain.activity.activitygroup.dao.ActivityGroupRepository;
 import page.clab.api.domain.activity.activitygroup.dao.GroupMemberRepository;
+import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupRole;
 import page.clab.api.domain.activity.activitygroup.exception.MemberNotPartOfActivityException;
 import page.clab.api.domain.activity.activitygroup.domain.GroupMemberStatus;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberDetailedInfoDto;
@@ -64,19 +65,21 @@ public class FileService {
 
     private static final Map<Role, Set<String>> roleCategoryMap = Map.of(
             Role.GUEST, Set.of("boards", "profiles", "activity-photos", "membership-fees"),
-            Role.USER, Set.of("boards", "profiles", "activity-photos", "membership-fees" , "weekly-activities", "assignments"),
-            Role.ADMIN, Set.of("boards", "profiles", "activity-photos", "membership-fees", "weekly-activities", "members", "assignments"),
-            Role.SUPER, Set.of("boards", "profiles", "activity-photos", "membership-fees", "weekly-activities", "members", "assignments")
+            Role.USER, Set.of("boards", "profiles", "activity-photos", "membership-fees" , "notices", "weekly-activities", "members", "assignments", "submits"),
+            Role.ADMIN, Set.of("boards", "profiles", "activity-photos", "membership-fees", "notices", "weekly-activities", "members", "assignments", "submits"),
+            Role.SUPER, Set.of("boards", "profiles", "activity-photos", "membership-fees", "notices", "weekly-activities", "members", "assignments", "submits")
     );
 
     private final Map<String, BiFunction<String, Authentication, Boolean>> categoryAccessMap = Map.of(
             "boards", (url, auth) -> true,
             "profiles", (url, auth) -> true,
-            "membership-fees", (url, auth) -> true,
             "activity-photos", (url, auth) -> true,
-            "weekly-activities", this::isWeeklyActivityAccessible,
+            "membership-fees", (url, auth) -> true,
+            "notices", this::isNonSubmitCategoryAccessible,
+            "weekly-activities", this::isNonSubmitCategoryAccessible,
+            "assignments", this::isNonSubmitCategoryAccessible,
             "members", this::isMemberAccessible,
-            "assignments", this::isAssignmentAccessible
+            "submits", this::isSubmitAccessible
     );
 
     public String saveQRCodeImage(byte[] QRCodeImage, String path, long storagePeriod, String nowDateTime) throws IOException {
@@ -143,21 +146,72 @@ public class FileService {
         return pathBuilder.toString();
     }
 
-    public void validatePathVariable(String path) throws InvalidPathVariableException {
+    public void validatePathVariable(String path) throws InvalidPathVariableException, PermissionDeniedException {
         String[] pathParts = path.split(Pattern.quote(File.separator));
         String pathStart = pathParts[0];
 
         switch (pathStart) {
-            case "assignments":
-                validateAssignmentPath(pathParts);
+            case "notices":
+                validateNoticePath(pathParts);
                 break;
             case "weekly-activities":
                 validateWeeklyActivityPath(pathParts);
                 break;
+            case "assignments":
+                validateAssignmentPath(pathParts);
+                break;
+            case "submits":
+                validateSubmitPath(pathParts);
+                break;
         }
     }
 
-    private void validateAssignmentPath(String[] pathParts) throws InvalidPathVariableException {
+    private void validateNoticePath(String[] pathParts) throws InvalidPathVariableException, PermissionDeniedException {
+        Long activityGroupId = parseId(pathParts[1], "활동 ID가 유효하지 않습니다.");
+        String memberId = externalRetrieveMemberUseCase.getCurrentMemberId();
+
+        if (!activityGroupRepository.existsById(activityGroupId)) {
+            throw new NotFoundException("해당 활동은 존재하지 않습니다.");
+        }
+        if (!groupMemberRepository.existsByMemberIdAndActivityGroupId(memberId, activityGroupId)) {
+            throw new MemberNotPartOfActivityException("해당 활동에 참여하고 있지 않은 멤버입니다.");
+        }
+        if (!activityGroupAdminService.isMemberGroupLeaderRole(activityGroupId, memberId)) {
+            throw new PermissionDeniedException("활동의 공지 관련 파일은 리더만 등록할 수 있습니다.");
+        }
+    }
+
+    private void validateWeeklyActivityPath(String[] pathParts) throws InvalidPathVariableException, PermissionDeniedException {
+        Long activityGroupId = parseId(pathParts[1], "활동 ID가 유효하지 않습니다.");
+        String memberId = externalRetrieveMemberUseCase.getCurrentMemberId();
+
+        if (!activityGroupRepository.existsById(activityGroupId)) {
+            throw new NotFoundException("해당 활동은 존재하지 않습니다.");
+        }
+        if (!groupMemberRepository.existsByMemberIdAndActivityGroupId(memberId, activityGroupId)) {
+            throw new MemberNotPartOfActivityException("해당 활동에 참여하고 있지 않은 멤버입니다.");
+        }
+        if (!activityGroupAdminService.isMemberGroupLeaderRole(activityGroupId, memberId)) {
+            throw new PermissionDeniedException("활동의 주차별 활동 관련 파일은 리더만 등록할 수 있습니다.");
+        }
+    }
+
+    private void validateAssignmentPath(String[] pathParts) throws InvalidPathVariableException, PermissionDeniedException {
+        Long activityGroupId = parseId(pathParts[1], "활동 ID가 유효하지 않습니다.");
+        String memberId = externalRetrieveMemberUseCase.getCurrentMemberId();
+
+        if (!activityGroupRepository.existsById(activityGroupId)) {
+            throw new NotFoundException("해당 활동은 존재하지 않습니다.");
+        }
+        if (!groupMemberRepository.existsByMemberIdAndActivityGroupId(memberId, activityGroupId)) {
+            throw new MemberNotPartOfActivityException("해당 활동에 참여하고 있지 않은 멤버입니다.");
+        }
+        if (!activityGroupAdminService.isMemberGroupLeaderRole(activityGroupId, memberId)) {
+            throw new PermissionDeniedException("활동의 과제 관련 파일은 리더만 등록할 수 있습니다.");
+        }
+    }
+
+    private void validateSubmitPath(String[] pathParts) throws InvalidPathVariableException {
         Long activityGroupId = parseId(pathParts[1], "활동 ID가 유효하지 않습니다.");
         Long activityGroupBoardId = parseId(pathParts[2], "활동 그룹 게시판 ID가 유효하지 않습니다.");
         String memberId = pathParts[3];
@@ -170,19 +224,7 @@ public class FileService {
             throw new MemberNotPartOfActivityException("해당 활동에 참여하고 있지 않은 멤버입니다.");
         }
         if (!activityGroupBoardRepository.existsById(activityGroupBoardId)) {
-            throw new NotFoundException("해당 활동 그룹 게시판이 존재하지 않습니다.");
-        }
-    }
-
-    private void validateWeeklyActivityPath(String[] pathParts) throws InvalidPathVariableException {
-        Long activityGroupId = parseId(pathParts[1], "활동 ID가 유효하지 않습니다.");
-        String memberId = externalRetrieveMemberUseCase.getCurrentMemberId();
-
-        if (!activityGroupRepository.existsById(activityGroupId)) {
-            throw new NotFoundException("해당 활동은 존재하지 않습니다.");
-        }
-        if (!groupMemberRepository.existsByMemberIdAndActivityGroupId(memberId, activityGroupId)) {
-            throw new MemberNotPartOfActivityException("해당 활동에 참여하고 있지 않은 멤버입니다.");
+            throw new NotFoundException("해당 활동 그룹 과제 게시판이 존재하지 않습니다.");
         }
     }
 
@@ -242,13 +284,21 @@ public class FileService {
         return categoryAccessMap.getOrDefault(category, (u, a) -> false).apply(url, authentication);
     }
 
+    private boolean isNonSubmitCategoryAccessible(String url, Authentication authentication) {
+        String memberId = authentication.getName();
+        String[] parts = url.split("/");
+        Long activityGroupId = Long.parseLong(parts[4]);
+
+        return groupMemberRepository.existsByActivityGroupIdAndMemberIdAndStatus(activityGroupId, memberId, GroupMemberStatus.ACCEPTED);
+    }
+
     private boolean isMemberAccessible(String url, Authentication authentication) {
         UploadedFile uploadedFile = uploadedFileService.getUploadedFileByUrl(url);
         String uploaderId = uploadedFile.getUploader();
         return authentication.getName().equals(uploaderId);
     }
 
-    private boolean isAssignmentAccessible(String url, Authentication authentication) {
+    private boolean isSubmitAccessible(String url, Authentication authentication) {
         UploadedFile uploadedFile = uploadedFileService.getUploadedFileByUrl(url);
         String uploaderId = uploadedFile.getUploader();
         String[] parts = url.split("/");
@@ -256,14 +306,6 @@ public class FileService {
 
         return authentication.getName().equals(uploaderId) ||
                 activityGroupAdminService.isMemberGroupLeaderRole(activityGroupId, authentication.getName());
-    }
-
-    private boolean isWeeklyActivityAccessible(String url, Authentication authentication) {
-        String memberId = authentication.getName();
-        String[] parts = url.split("/");
-        Long activityGroupId = Long.parseLong(parts[4]);
-
-        return groupMemberRepository.existsByActivityGroupIdAndMemberIdAndStatus(activityGroupId, memberId, GroupMemberStatus.ACCEPTED);
     }
 
     private String getCategoryByUrl(String url) {

--- a/src/main/java/page/clab/api/global/common/file/application/FileService.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileService.java
@@ -286,10 +286,12 @@ public class FileService {
 
     private boolean isNonSubmitCategoryAccessible(String url, Authentication authentication) {
         String memberId = authentication.getName();
+        Member member = externalRetrieveMemberUseCase.findByIdOrThrow(memberId);
         String[] parts = url.split("/");
         Long activityGroupId = Long.parseLong(parts[4]);
 
-        return groupMemberRepository.existsByActivityGroupIdAndMemberIdAndStatus(activityGroupId, memberId, GroupMemberStatus.ACCEPTED);
+        return member.isSuperAdminRole() ||
+                groupMemberRepository.existsByActivityGroupIdAndMemberIdAndStatus(activityGroupId, memberId, GroupMemberStatus.ACCEPTED);
     }
 
     private boolean isMemberAccessible(String url, Authentication authentication) {
@@ -301,10 +303,12 @@ public class FileService {
     private boolean isSubmitAccessible(String url, Authentication authentication) {
         UploadedFile uploadedFile = uploadedFileService.getUploadedFileByUrl(url);
         String uploaderId = uploadedFile.getUploader();
+        String memberId = authentication.getName();
+        Member member = externalRetrieveMemberUseCase.findByIdOrThrow(memberId);
         String[] parts = url.split("/");
         Long activityGroupId = Long.parseLong(parts[4]);
 
-        return authentication.getName().equals(uploaderId) ||
+        return memberId.equals(uploaderId) || member.isSuperAdminRole() ||
                 activityGroupAdminService.isMemberGroupLeaderRole(activityGroupId, authentication.getName());
     }
 

--- a/src/main/java/page/clab/api/global/common/file/application/FileService.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileService.java
@@ -196,13 +196,13 @@ public class FileService {
         validateIsMemberGroupLeader(activityGroupId, memberId, "활동의 과제 관련 파일은 리더만 등록할 수 있습니다.");
     }
 
-    private void validateSubmitPath(String[] pathParts) throws InvalidPathVariableException, PermissionDeniedException {
+    private void validateSubmitPath(String[] pathParts) throws InvalidPathVariableException {
         Long activityGroupId = parseId(pathParts[1], "활동 ID가 유효하지 않습니다.");
         Long activityGroupBoardId = parseId(pathParts[2], "활동 그룹 게시판 ID가 유효하지 않습니다.");
         String memberId = pathParts[3];
 
         validateActivityGroupExist(activityGroupId);
-        validateIsSubmitter(memberId, activityGroupId);
+        validateIsMemberPartOfActivity(memberId, activityGroupId);
         ActivityGroupBoard activityGroupBoard = activityGroupBoardService.getActivityGroupBoardByIdOrThrow(activityGroupBoardId);
         validateIsParentBoardAssignment(activityGroupBoard);
     }
@@ -228,13 +228,6 @@ public class FileService {
     private void validateIsParentBoardAssignment(ActivityGroupBoard activityGroupBoard) {
         if (!activityGroupBoard.isAssignment()) {
             throw new InvalidParentBoardException("부모 게시판이 ASSIGNMENT가 아닙니다.");
-        }
-    }
-
-    private void validateIsSubmitter(String memberId, Long activityGroupId) {
-        Optional<Member> assignmentWriterOpt = externalRetrieveMemberUseCase.findById(memberId);
-        if (assignmentWriterOpt.isEmpty() || !groupMemberRepository.existsByMemberIdAndActivityGroupId(assignmentWriterOpt.get().getId(), activityGroupId)) {
-            throw new MemberNotPartOfActivityException("해당 활동에 참여하고 있지 않은 멤버입니다.");
         }
     }
 


### PR DESCRIPTION
## Summary

> #531 

활동 2차 QA 후 파일 업로드 시 발생하는 최적화 예외 발생을 핸들링하고
추가적인 활동 관련 파일 업로드 API를 작성하고자 했습니다.

## Tasks
1. 파일 업로드 시 회전값을 사용한 최적화 로직에서 오류 발생할 경우 원본 이미지를 저장하도록 수정
2. 활동 카테고리의 NOTICE에서 사용할 파일 업로드 API 작성
3. 파일 업로드 API 내에서 ASSIGNMENT, SUBMIT의 불명확한 로직 재정립

## Screenshot

1. 파일 업로드 시 orientation값이 없는 경우 예외를 발생시키고 500에러가 반환되었습니다.
이를 회전값 최적화 없이 원본 사진을 저장하고 log로 warning만 기록하도록 수정하였습니다.

수정 전
![image](https://github.com/user-attachments/assets/71074867-2ee9-444d-92f1-dd65e4f1dc3b)
수정 후
![image](https://github.com/user-attachments/assets/f667a936-ec84-4f3f-a04f-35fe4124674d)
경로로 접근한 파일
![image](https://github.com/user-attachments/assets/6aa93dde-f89e-42ef-b88d-4371e8ab732e)


2. NOTICE, ASSIGNMENT, SUBMIT 관련 파일 업로드 API를 재정립했습니다.
ASSIGNMENT의 경우는 그룹장이 과제 양식을 올릴 때 사용할 수 있도록 activityGroupId만 파라미터로 받습니다.
SUBMIT의 경우는 그룹원이 과제를 제출 파일을 올릴 때 사용할 수 있도록 activityGroupId와 부모게시판인 ASSIGNMENT의 id 값을 parentBoardId로 전달하도록 했습니다.

- 그룹원이 NOTICE, ASSIGNMENT 관련 파일을 등록할 경우 아래와 같이 403 에러를 발생시킵니다
![image](https://github.com/user-attachments/assets/5c2739ec-7377-4ee7-8f9b-348759ec0686)

- 제출의 경우는 활동에 참여중인 그룹원만 아래와 같이 등록할 수 있습니다.
![image](https://github.com/user-attachments/assets/a50f3086-aefc-43a3-bbf2-7a93f3e757a9)

- SUBMIT 파일 업로드 시 부모 게시판의 카테고리가 ASSIGNMENT인지 판단하는 로직이 추가되었습니다.
<img width="787" alt="image" src="https://github.com/user-attachments/assets/1a03f0dc-a836-4920-94a5-9907767a2ebc">

