### PR TITLE
refactor: 활동관련 2차 QA에 따른 활동 게시판 로직 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupMemberController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupMemberController.java
@@ -40,7 +40,7 @@ public class ActivityGroupMemberController {
     private final ActivityGroupMemberService activityGroupMemberService;
     private final PageableUtils pageableUtils;
 
-    @Operation(summary = "[U] 활동 상세 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함")
+    @Operation(summary = "[U] 활동 상세 조회", description = "ROLE_USER 이상의 권한이 필요함")
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/{activityGroupId}")
     public ApiResponse<ActivityGroupDetailResponseDto> getActivityGroup(

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -54,8 +54,6 @@ public class ActivityGroupAdminService {
     public Long createActivityGroup(ActivityGroupRequestDto requestDto) {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroup activityGroup = ActivityGroupRequestDto.toEntity(requestDto);
-        activityGroup.validateContentLength();
-        activityGroup.validateCurriculumLength();
         activityGroup.validateAndSetGithubUrl(activityGroup.getGithubUrl());
         activityGroupRepository.save(activityGroup);
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -55,6 +55,7 @@ public class ActivityGroupAdminService {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroup activityGroup = ActivityGroupRequestDto.toEntity(requestDto);
         activityGroup.validateContentLength();
+        activityGroup.validateCurriculumLength();
         activityGroup.validateAndSetGithubUrl(activityGroup.getGithubUrl());
         activityGroupRepository.save(activityGroup);
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ActivityGroup.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ActivityGroup.java
@@ -20,6 +20,7 @@ import org.hibernate.validator.constraints.Range;
 import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupUpdateRequestDto;
 import page.clab.api.domain.activity.activitygroup.exception.ActivityGroupNotProgressingException;
 import page.clab.api.domain.activity.activitygroup.exception.ContentLengthExceededException;
+import page.clab.api.domain.activity.activitygroup.exception.CurriculumLengthExceededException;
 import page.clab.api.domain.activity.activitygroup.exception.InvalidGithubUrlException;
 import page.clab.api.global.common.domain.BaseEntity;
 
@@ -51,8 +52,8 @@ public class ActivityGroup extends BaseEntity {
     @Size(min = 1, max = 30, message = "{size.activityGroup.name}")
     private String name;
 
-    @Column(nullable = false, length = 200)
-    @Size(min = 1, max = 200, message = "{size.activityGroup.content}")
+    @Column(nullable = false, length = 1000)
+    @Size(min = 1, max = 1000, message = "{size.activityGroup.content}")
     private String content;
 
     @Column(nullable = false)
@@ -64,6 +65,8 @@ public class ActivityGroup extends BaseEntity {
 
     private String imageUrl;
 
+    @Column(length = 1000)
+    @Size(min = 1, max = 1000, message = "{size.activityGroup.curriculum}")
     private String curriculum;
 
     private LocalDate startDate;
@@ -83,7 +86,7 @@ public class ActivityGroup extends BaseEntity {
         Optional.ofNullable(requestDto.getName()).ifPresent(this::setName);
         Optional.ofNullable(requestDto.getContent()).ifPresent(this::validateAndSetContentLength);
         Optional.ofNullable(requestDto.getImageUrl()).ifPresent(this::setImageUrl);
-        Optional.ofNullable(requestDto.getCurriculum()).ifPresent(this::setCurriculum);
+        Optional.ofNullable(requestDto.getCurriculum()).ifPresent(this::validateAndSetCurriculumLength);
         Optional.ofNullable(requestDto.getStartDate()).ifPresent(this::setStartDate);
         Optional.ofNullable(requestDto.getEndDate()).ifPresent(this::setEndDate);
         Optional.ofNullable(requestDto.getTechStack()).ifPresent(this::setTechStack);
@@ -116,15 +119,28 @@ public class ActivityGroup extends BaseEntity {
         }
     }
 
+    public void validateCurriculumLength() {
+        if (this.curriculum != null && this.curriculum.length() > 1000) {
+            throw new CurriculumLengthExceededException("활동 커리큘럼은 1000자 이하여야 합니다.");
+        }
+    }
+
+    public void validateAndSetCurriculumLength(String curriculum) {
+        if (curriculum != null && curriculum.length() > 1000) {
+            throw new CurriculumLengthExceededException("활동 커리큘럼은 1000자 이하여야 합니다.");
+        }
+        this.curriculum = curriculum;
+    }
+
     public void validateContentLength() {
-        if (this.content != null && this.content.length() > 200) {
-            throw new ContentLengthExceededException("활동 설명은 200자 이하여야 합니다.");
+        if (this.content != null && this.content.length() > 1000) {
+            throw new ContentLengthExceededException("활동 설명은 1000자 이하여야 합니다.");
         }
     }
 
     public void validateAndSetContentLength(String content) {
-        if (content != null && content.length() > 200) {
-            throw new ContentLengthExceededException("활동 설명은 200자 이하여야 합니다.");
+        if (content != null && content.length() > 1000) {
+            throw new ContentLengthExceededException("활동 설명은 1000자 이하여야 합니다.");
         }
         this.content = content;
     }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ActivityGroup.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ActivityGroup.java
@@ -19,8 +19,6 @@ import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.validator.constraints.Range;
 import page.clab.api.domain.activity.activitygroup.dto.request.ActivityGroupUpdateRequestDto;
 import page.clab.api.domain.activity.activitygroup.exception.ActivityGroupNotProgressingException;
-import page.clab.api.domain.activity.activitygroup.exception.ContentLengthExceededException;
-import page.clab.api.domain.activity.activitygroup.exception.CurriculumLengthExceededException;
 import page.clab.api.domain.activity.activitygroup.exception.InvalidGithubUrlException;
 import page.clab.api.global.common.domain.BaseEntity;
 
@@ -84,9 +82,9 @@ public class ActivityGroup extends BaseEntity {
         Optional.ofNullable(requestDto.getCategory()).ifPresent(this::setCategory);
         Optional.ofNullable(requestDto.getSubject()).ifPresent(this::setSubject);
         Optional.ofNullable(requestDto.getName()).ifPresent(this::setName);
-        Optional.ofNullable(requestDto.getContent()).ifPresent(this::validateAndSetContentLength);
+        Optional.ofNullable(requestDto.getContent()).ifPresent(this::setContent);
         Optional.ofNullable(requestDto.getImageUrl()).ifPresent(this::setImageUrl);
-        Optional.ofNullable(requestDto.getCurriculum()).ifPresent(this::validateAndSetCurriculumLength);
+        Optional.ofNullable(requestDto.getCurriculum()).ifPresent(this::setCurriculum);
         Optional.ofNullable(requestDto.getStartDate()).ifPresent(this::setStartDate);
         Optional.ofNullable(requestDto.getEndDate()).ifPresent(this::setEndDate);
         Optional.ofNullable(requestDto.getTechStack()).ifPresent(this::setTechStack);
@@ -117,32 +115,6 @@ public class ActivityGroup extends BaseEntity {
         if (!this.isProgressing()) {
             throw new ActivityGroupNotProgressingException("해당 활동은 진행중인 활동이 아닙니다.");
         }
-    }
-
-    public void validateCurriculumLength() {
-        if (this.curriculum != null && this.curriculum.length() > 1000) {
-            throw new CurriculumLengthExceededException("활동 커리큘럼은 1000자 이하여야 합니다.");
-        }
-    }
-
-    public void validateAndSetCurriculumLength(String curriculum) {
-        if (curriculum != null && curriculum.length() > 1000) {
-            throw new CurriculumLengthExceededException("활동 커리큘럼은 1000자 이하여야 합니다.");
-        }
-        this.curriculum = curriculum;
-    }
-
-    public void validateContentLength() {
-        if (this.content != null && this.content.length() > 1000) {
-            throw new ContentLengthExceededException("활동 설명은 1000자 이하여야 합니다.");
-        }
-    }
-
-    public void validateAndSetContentLength(String content) {
-        if (content != null && content.length() > 1000) {
-            throw new ContentLengthExceededException("활동 설명은 1000자 이하여야 합니다.");
-        }
-        this.content = content;
     }
 
     /**

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/exception/ContentLengthExceededException.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/exception/ContentLengthExceededException.java
@@ -1,8 +1,0 @@
-package page.clab.api.domain.activity.activitygroup.exception;
-
-public class ContentLengthExceededException extends RuntimeException {
-
-    public ContentLengthExceededException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/exception/CurriculumLengthExceededException.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/exception/CurriculumLengthExceededException.java
@@ -1,0 +1,8 @@
+package page.clab.api.domain.activity.activitygroup.exception;
+
+public class CurriculumLengthExceededException extends RuntimeException {
+
+    public CurriculumLengthExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/exception/CurriculumLengthExceededException.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/exception/CurriculumLengthExceededException.java
@@ -1,8 +1,0 @@
-package page.clab.api.domain.activity.activitygroup.exception;
-
-public class CurriculumLengthExceededException extends RuntimeException {
-
-    public CurriculumLengthExceededException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
@@ -30,6 +30,7 @@ import page.clab.api.domain.activity.activitygroup.exception.AlreadyAppliedExcep
 import page.clab.api.domain.activity.activitygroup.exception.AlreadySubmittedThisWeekAssignmentException;
 import page.clab.api.domain.activity.activitygroup.exception.AssignmentBoardHasNoDueDateTimeException;
 import page.clab.api.domain.activity.activitygroup.exception.ContentLengthExceededException;
+import page.clab.api.domain.activity.activitygroup.exception.CurriculumLengthExceededException;
 import page.clab.api.domain.activity.activitygroup.exception.DuplicateAbsentExcuseException;
 import page.clab.api.domain.activity.activitygroup.exception.DuplicateAttendanceException;
 import page.clab.api.domain.activity.activitygroup.exception.DuplicateReportException;
@@ -127,6 +128,7 @@ public class GlobalExceptionHandler {
             AssignmentBoardHasNoDueDateTimeException.class,
             FeedbackBoardHasNoContentException.class,
             ContentLengthExceededException.class,
+            CurriculumLengthExceededException.class
     })
     public ErrorResponse<Exception> badRequestException(HttpServletResponse response, Exception e) {
         response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
@@ -29,8 +29,6 @@ import page.clab.api.domain.activity.activitygroup.exception.ActivityGroupNotPro
 import page.clab.api.domain.activity.activitygroup.exception.AlreadyAppliedException;
 import page.clab.api.domain.activity.activitygroup.exception.AlreadySubmittedThisWeekAssignmentException;
 import page.clab.api.domain.activity.activitygroup.exception.AssignmentBoardHasNoDueDateTimeException;
-import page.clab.api.domain.activity.activitygroup.exception.ContentLengthExceededException;
-import page.clab.api.domain.activity.activitygroup.exception.CurriculumLengthExceededException;
 import page.clab.api.domain.activity.activitygroup.exception.DuplicateAbsentExcuseException;
 import page.clab.api.domain.activity.activitygroup.exception.DuplicateAttendanceException;
 import page.clab.api.domain.activity.activitygroup.exception.DuplicateReportException;
@@ -126,9 +124,7 @@ public class GlobalExceptionHandler {
             SortingArgumentException.class,
             UnknownPathException.class,
             AssignmentBoardHasNoDueDateTimeException.class,
-            FeedbackBoardHasNoContentException.class,
-            ContentLengthExceededException.class,
-            CurriculumLengthExceededException.class
+            FeedbackBoardHasNoContentException.class
     })
     public ErrorResponse<Exception> badRequestException(HttpServletResponse response, Exception e) {
         response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,6 +1,7 @@
 size.accuse.reason=신고 사유는 {min}자 이상 {max}자 이하로 입력하세요.
 size.activityGroup.name=이름은 {min}자 이상 {max}자 이하로 입력하세요.
 size.activityGroup.content=내용은 {min}자 이상 {max}자 이하로 입력하세요.
+size.activityGroup.curriculum=커리큘럼은 {min}자 이상 {max}자 이하로 입력하세요.
 size.activityGroupBoard.title=제목은 {min}자 이상 {max}자 이하로 입력하세요.
 size.application.studentId=학번은 {min}자 이상 {max}자 이하로 입력하세요.
 size.application.name=이름은 {min}자 이상 {max}자 이하로 입력하세요.


### PR DESCRIPTION
## Summary

>#530

활동 생성 시 내용과 커리큘럼의 글자 수 제한 1000자로 수정하였습니다.
이슈에 있었던 남은 2가지 task는 @Jeong-Ag님과 운영진과 상의하여 프론트에서 수정하는 것으로 결정하였습니다.

## Tasks

- 활동 생성 시 내용과 커리큘럼의 글자 수 제한 1000자로 수정
## ETC
코어팀 노션에 아래와 같이 새로운 예외에 대한 설명도 올려놨습니다.
![image](https://github.com/user-attachments/assets/17d35d3d-1cc3-4801-953c-93877f9f0dd9)

**칼럼 제약사항 쿼리문**
```
ALTER TABLE activity_group
ALTER COLUMN content TYPE VARCHAR(1000),
ALTER COLUMN content SET NOT NULL,
ALTER COLUMN curriculum TYPE VARCHAR(1000);
```

## Screenshot

내용이 1000자가 넘을 경우
![image](https://github.com/user-attachments/assets/35e4a269-be08-4559-9487-ee362c71baa7)

커리큘럼이 1000자가 넘을 경우
![image](https://github.com/user-attachments/assets/6cb094ba-bdc8-4e2f-9723-5ba842bc141d)
