### PR TITLE
refactor: 활동 관련 2차 QA에 따른 활동 관리 로직 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
@@ -126,7 +126,7 @@ public class ActivityGroupAdminController {
         return ApiResponse.success(groupMembers);
     }
 
-    @Operation(summary = "[U] 신청 멤버 상태 변경", description = "ROLE_USER 이상의 권한이 필요함")
+    @Operation(summary = "[U] 신청 멤버 상태 개별 변경", description = "ROLE_USER 이상의 권한이 필요함")
     @PreAuthorize("hasRole('USER')")
     @PatchMapping("/accept")
     public ApiResponse<Long> acceptGroupMember(
@@ -135,6 +135,18 @@ public class ActivityGroupAdminController {
             @RequestParam(name = "status") GroupMemberStatus status
     ) throws PermissionDeniedException {
         Long id = activityGroupAdminService.manageGroupMemberStatus(activityGroupId, memberId, status);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(summary = "[U] 신청 멤버 상태 통합 변경", description = "ROLE_USER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('USER')")
+    @PatchMapping("/accept-multiple")
+    public ApiResponse<Long> acceptGroupMembers(
+            @RequestParam(name = "activityGroupId") Long activityGroupId,
+            @RequestParam(name = "memberId") List<String> memberIds,
+            @RequestParam(name = "status") GroupMemberStatus status
+    ) throws PermissionDeniedException {
+        Long id = activityGroupAdminService.manageGroupMemberStatus(activityGroupId, memberIds, status);
         return ApiResponse.success(id);
     }
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
@@ -126,22 +126,10 @@ public class ActivityGroupAdminController {
         return ApiResponse.success(groupMembers);
     }
 
-    @Operation(summary = "[U] 신청 멤버 상태 개별 변경", description = "ROLE_USER 이상의 권한이 필요함")
+    @Operation(summary = "[U] 신청 멤버 상태 변경", description = "ROLE_USER 이상의 권한이 필요함")
     @PreAuthorize("hasRole('USER')")
     @PatchMapping("/accept")
     public ApiResponse<Long> acceptGroupMember(
-            @RequestParam(name = "activityGroupId") Long activityGroupId,
-            @RequestParam(name = "memberId") String memberId,
-            @RequestParam(name = "status") GroupMemberStatus status
-    ) throws PermissionDeniedException {
-        Long id = activityGroupAdminService.manageGroupMemberStatus(activityGroupId, memberId, status);
-        return ApiResponse.success(id);
-    }
-
-    @Operation(summary = "[U] 신청 멤버 상태 통합 변경", description = "ROLE_USER 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('USER')")
-    @PatchMapping("/accept-multiple")
-    public ApiResponse<Long> acceptGroupMembers(
             @RequestParam(name = "activityGroupId") Long activityGroupId,
             @RequestParam(name = "memberId") List<String> memberIds,
             @RequestParam(name = "status") GroupMemberStatus status

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -163,15 +163,6 @@ public class ActivityGroupAdminService {
     }
 
     @Transactional
-    public Long manageGroupMemberStatus(Long activityGroupId, String memberId, GroupMemberStatus status) throws PermissionDeniedException {
-        Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
-        ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);
-        validateLeaderPermission(activityGroup, currentMember, "해당 활동의 신청 멤버를 조회할 권한이 없습니다.");
-        updateGroupMemberStatus(memberId, status, activityGroup);
-        return activityGroup.getId();
-    }
-
-    @Transactional
     public Long manageGroupMemberStatus(Long activityGroupId, List<String> memberIds, GroupMemberStatus status) throws PermissionDeniedException {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
@@ -34,6 +35,7 @@ import page.clab.api.global.common.dto.PagedResponseDto;
 import page.clab.api.global.exception.NotFoundException;
 import page.clab.api.global.exception.PermissionDeniedException;
 
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -193,6 +195,19 @@ public class ActivityGroupAdminService {
         activityGroupMemberService.save(groupMember);
 
         return activityGroup.getId();
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateActivityGroupStatusEnd() {
+        List<ActivityGroup> activityGroups = activityGroupRepository.findByEndDateBefore(LocalDate.now());
+        activityGroups.forEach(this::updateActivityGroupStatusEnd);
+    }
+
+    private void updateActivityGroupStatusEnd(ActivityGroup activityGroup) {
+        if (!activityGroup.getStatus().equals(ActivityGroupStatus.END)) {
+            activityGroup.updateStatus(ActivityGroupStatus.END);
+            activityGroupRepository.save(activityGroup);
+        }
     }
 
     private void updateGroupMemberStatus(String memberId, GroupMemberStatus status, ActivityGroup activityGroup) {

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -199,15 +199,15 @@ public class ActivityGroupAdminService {
 
     @Scheduled(cron = "0 0 0 * * *")
     public void updateActivityGroupStatusEnd() {
-        List<ActivityGroup> activityGroups = activityGroupRepository.findByEndDateBefore(LocalDate.now());
-        activityGroups.forEach(this::updateActivityGroupStatusEnd);
+        List<ActivityGroup> activityGroups = activityGroupRepository.findByEndDateBeforeAndStatusNot(LocalDate.now(), ActivityGroupStatus.END);
+        if(!activityGroups.isEmpty()){
+            activityGroups.forEach(this::updateActivityGroupStatusEnd);
+        }
     }
 
     private void updateActivityGroupStatusEnd(ActivityGroup activityGroup) {
-        if (!activityGroup.getStatus().equals(ActivityGroupStatus.END)) {
-            activityGroup.updateStatus(ActivityGroupStatus.END);
-            activityGroupRepository.save(activityGroup);
-        }
+        activityGroup.updateStatus(ActivityGroupStatus.END);
+        activityGroupRepository.save(activityGroup);
     }
 
     private void updateGroupMemberStatus(String memberId, GroupMemberStatus status, ActivityGroup activityGroup) {

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -90,22 +90,22 @@ public class ActivityGroupMemberService {
                 .distinct()
                 .toList();
 
-        List<ActivityGroupStatusResponseDto> activityGroupDtos = activityGroups.stream()
+        List<ActivityGroup> paginatedActivityGroups = activityGroups.stream()
+                .skip(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .toList();
+
+        List<ActivityGroupStatusResponseDto> activityGroupDtos = paginatedActivityGroups.stream()
                 .map(this::getActivityGroupStatusResponseDto)
                 .toList();
 
-        return new PagedResponseDto<>(activityGroupDtos, pageable, activityGroupDtos.size());
+        return new PagedResponseDto<>(activityGroupDtos, activityGroups.size(), pageable);
     }
 
     @Transactional(readOnly = true)
     public PagedResponseDto<ActivityGroupStatusResponseDto> getActivityGroupsByStatus(ActivityGroupStatus status, Pageable pageable) {
-        List<ActivityGroup> activityGroups = activityGroupRepository.findActivityGroupsByStatus(status);
-
-        List<ActivityGroupStatusResponseDto> activityGroupDtos = activityGroups.stream()
-                .map(this::getActivityGroupStatusResponseDto)
-                .toList();
-
-        return new PagedResponseDto<>(activityGroupDtos, pageable, activityGroupDtos.size());
+        Page<ActivityGroup> activityGroups = activityGroupRepository.findActivityGroupsByStatus(status, pageable);
+        return new PagedResponseDto<>(activityGroups.map(this::getActivityGroupStatusResponseDto));
     }
 
     @Transactional(readOnly = true)
@@ -161,7 +161,13 @@ public class ActivityGroupMemberService {
                 .distinct()
                 .map(this::getActivityGroupStatusResponseDto)
                 .toList();
-        return new PagedResponseDto<>(activityGroups, pageable, activityGroups.size());
+
+        List<ActivityGroupStatusResponseDto> paginatedActivityGroups = activityGroups.stream()
+                .skip(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .toList();
+
+        return new PagedResponseDto<>(paginatedActivityGroups, activityGroups.size(), pageable);
     }
 
     private ActivityGroupStatusResponseDto getActivityGroupStatusResponseDto(ActivityGroup activityGroup) {

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepository.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepository.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Repository;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroup;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupCategory;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface ActivityGroupRepository extends JpaRepository<ActivityGroup, Long>, ActivityGroupRepositoryCustom, QuerydslPredicateExecutor<ActivityGroup> {
 
@@ -16,4 +19,6 @@ public interface ActivityGroupRepository extends JpaRepository<ActivityGroup, Lo
 
     @Query(value = "SELECT a.* FROM activity_group a WHERE a.is_deleted = true", nativeQuery = true)
     Page<ActivityGroup> findAllByIsDeletedTrue(Pageable pageable);
+
+    List<ActivityGroup> findByEndDateBefore(LocalDate now);
 }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepository.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroup;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupCategory;
+import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupStatus;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -20,5 +21,5 @@ public interface ActivityGroupRepository extends JpaRepository<ActivityGroup, Lo
     @Query(value = "SELECT a.* FROM activity_group a WHERE a.is_deleted = true", nativeQuery = true)
     Page<ActivityGroup> findAllByIsDeletedTrue(Pageable pageable);
 
-    List<ActivityGroup> findByEndDateBefore(LocalDate now);
+    List<ActivityGroup> findByEndDateBeforeAndStatusNot(LocalDate now, ActivityGroupStatus status);
 }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepositoryCustom.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepositoryCustom.java
@@ -1,10 +1,11 @@
 package page.clab.api.domain.activity.activitygroup.dao;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroup;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupStatus;
 
-import java.util.List;
-
 public interface ActivityGroupRepositoryCustom {
-    List<ActivityGroup> findActivityGroupsByStatus(ActivityGroupStatus status);
+
+    Page<ActivityGroup> findActivityGroupsByStatus(ActivityGroupStatus status, Pageable pageable);
 }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepositoryCustomImpl.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepositoryCustomImpl.java
@@ -3,6 +3,9 @@ package page.clab.api.domain.activity.activitygroup.dao;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroup;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupStatus;
@@ -17,14 +20,25 @@ public class ActivityGroupRepositoryCustomImpl implements ActivityGroupRepositor
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<ActivityGroup> findActivityGroupsByStatus(ActivityGroupStatus status) {
+    public Page<ActivityGroup> findActivityGroupsByStatus(ActivityGroupStatus status, Pageable pageable) {
         QActivityGroup qActivityGroup = QActivityGroup.activityGroup;
         BooleanBuilder builder = new BooleanBuilder();
 
         if (status != null) builder.and(qActivityGroup.status.eq(status));
 
-        return queryFactory.selectFrom(qActivityGroup)
+        List<ActivityGroup> activityGroups = queryFactory.selectFrom(qActivityGroup)
                 .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
+
+        Long total = queryFactory.select(qActivityGroup.count())
+                .from(qActivityGroup)
+                .where(builder)
+                .fetchOne();
+
+        long totalElements = total != null ? total : 0;
+
+        return new PageImpl<>(activityGroups, pageable, totalElements);
     }
 }

--- a/src/main/java/page/clab/api/global/common/dto/PagedResponseDto.java
+++ b/src/main/java/page/clab/api/global/common/dto/PagedResponseDto.java
@@ -104,6 +104,24 @@ public class PagedResponseDto<T> {
     }
 
     /**
+     * List와 Pageable 객체를 사용하여 PagedResponseDto를 생성하는 생성자입니다.
+     * 페이지네이션과 정렬이 적용됩니다.
+     *
+     * @param ts 콘텐츠 아이템 리스트
+     * @param totalItems 전체 아이템 수
+     * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
+     */
+    public PagedResponseDto(List<T> ts, int totalItems, Pageable pageable) {
+        this.currentPage = pageable.getPageNumber();
+        this.hasPrevious = pageable.getPageNumber() > 0;
+        this.hasNext = pageable.getOffset() + pageable.getPageSize() < totalItems;
+        this.totalPages = (totalItems != 0) ? (int) Math.ceil((double) totalItems / pageable.getPageSize()) : 0;
+        this.totalItems = totalItems;
+        this.take = ts.size();
+        this.items = applySortingIfNecessary(ts, pageable.getSort());
+    }
+
+    /**
      * 정렬이 필요한 경우 아이템 리스트에 정렬을 적용하는 메서드입니다.
      *
      * @param items 정렬되지 않은 아이템 리스트


### PR DESCRIPTION
## Summary

> #533 

활동 2차 QA에서 나온 활동 관리 이슈들을 수정했습니다.
1. 활동을 신청한 멤버의 리스트가 요청으로 들어오면 통합적으로 상태를 변경하는 api를 구현했습니다.
2. 스터디 종료 일자가 지날 시, 자동으로 상태를 `END`로 업데이트 해주는 스케줄러를 구현했습니다.
3. **내가 지원한 활동 목록 조회**, **나의 활동 목록 조회**, **활동 상태별 조회**에서 size를 변경해도, size에 따라 페이징 되지 않고 전체 데이터가 반환되는 현상을 수정했습니다.

## Tasks

- 활동 신청 멤버를 일괄 승인 할 수 있는 API 추가
- 스터디 종료 일자 후에 자동으로 상태를 END로 변경할 수 있도록 수정
- 활동 상태별 조회 시 페이징 미적용 문제 확인

## ETC

`PageResponseDto`에서, 새로운 생성자를 추가했습니다. **내가 지원한 활동 목록 조회**, **나의 활동 목록 조회**, **활동 상태별 조회**에서 `List`를 매개변수로 받는 `PageResponseDto`생성자를 사용했었는데, 페이지네이션 되지 않은 `List`가 전달되어 전체 데이터가 반환되고 있었습니다.
하지만 `currentMemberId`로부터  `ActivityGroupMember`를 조회하여 해당 그룹 멤버의 활동을 가져오는 방식이기 때문에, `ActivityGroupMember`에 페이지네이션을 적용해봤자 이후에 필터링되는 과정에서 데이터가 달라지므로 기존의  **`List`를 매개변수로 받는 `PageResponseDto`생성자**를 사용할 수 없었습니다.
따라서, 같은 매개변수를 받지만 동작이 다른 생성자를 추가하게 되었습니다.
더 좋은 방법이 있으면 피드백 해주시면 감사하겠습니다!

## Screenshot

- 활동 상태별 조회시, **총 데이터가 2개**일 때 **size를 1**로 한 결과
```
{
  "success": true,
  "data": {
    "currentPage": 1,
    "hasPrevious": true,
    "hasNext": false,
    "totalPages": 2,
    "totalItems": 2,
    "take": 1,
    "items": [
      {
        "id": 7,
        "name": "test",
        "content": "test",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "image.png",
        "leaders": [
          {
            "id": "000000000",
            "name": "관리자"
          }
        ],
        "participantCount": 1,
        "weeklyActivityCount": 0,
        "createdAt": "2024-09-07T12:36:44.223115"
      }
    ]
  }
}
```

- 상태 자동 업데이트 (9월 8일 Progressing)
![스크린샷 2024-09-08 232009](https://github.com/user-attachments/assets/e30decb6-854e-4155-93c0-cfaf249a5315)

- 상태 자동 업데이트 (9월 9일이 되자, End로 변경)
![스크린샷 2024-09-09 001015](https://github.com/user-attachments/assets/456705e4-0d8f-4cc3-82f4-da21c94ef6bc)

