### PR TITLE
refactor : 지원 알림에 모집 종류 명시하도록 수정

### DIFF
--- a/src/main/java/page/clab/api/domain/hiring/application/application/service/ApplicationApplyService.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/application/service/ApplicationApplyService.java
@@ -25,8 +25,9 @@ public class ApplicationApplyService implements ApplyForApplicationUseCase {
     public String applyForClub(ApplicationRequestDto requestDto) {
         externalRetrieveRecruitmentUseCase.validateRecruitmentForApplication(requestDto.getRecruitmentId());
         Application application = ApplicationRequestDto.toEntity(requestDto);
-        externalSendNotificationUseCase.sendNotificationToAdmins(requestDto.getStudentId() + " " +
-                requestDto.getName() + "님이 동아리에 지원하였습니다.");
+        String applicationType = application.getApplicationTypeForNotificationPrefix();
+        externalSendNotificationUseCase.sendNotificationToAdmins(applicationType + requestDto.getStudentId() + " " +
+                requestDto.getName() + "님이 지원하였습니다.");
         slackService.sendNewApplicationNotification(requestDto);
         return registerApplicationPort.save(application).getStudentId();
     }

--- a/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
@@ -44,6 +44,6 @@ public class Application {
     }
 
     public String getApplicationTypeForNotificationPrefix() {
-        return "[" + this.applicationType + "] ";
+        return "[" + this.applicationType.getDescription() + "] ";
     }
 }

--- a/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
@@ -42,4 +42,8 @@ public class Application {
     public void reject() {
         this.isPass = false;
     }
+
+    public String getApplicationTypeForNotificationPrefix() {
+        return "[" + this.applicationType + "] ";
+    }
 }


### PR DESCRIPTION
## Summary

> #540 

지원 알림에 모집 공고 명시하도록 수정하였습니다.
계획 단계에서는 `[CORE_TEAM]-` 형태로 명시하도록 했는데, 
@Jeong-Ag님과 결과물을 보면서 `[CORE_TEAM]` 로 명시하는 것이
더 가독성이 좋아 해당 형식으로 수정하였습니다.

## Tasks

- 지원 알림에 모집 공고 명시

## ETC

기존에 생성된 알림내용의 경우, 바뀐 정책대로 데이터를 수정하고자 하였으나, 
Notification 테이블에는 모집 종류를 저장하는 칼럼이 없어 수정이 불가능했습니다.
앞으로 생성되는 지원 알림에 대해서만 해당 알림 생성규칙이 적용될 예정입니다.

## Screenshot

<img width="749" alt="image" src="https://github.com/user-attachments/assets/b5bd5c9f-60c9-4dbf-873a-5514b9bc0b4b">
