### PR TITLE
refactor: 지원 관련 글자수 제한 설정

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ApplyForm.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ApplyForm.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,6 +34,7 @@ public class ApplyForm extends BaseEntity {
 
     private String memberId;
 
+    @Size(min = 1, max = 1000, message = "{size.applyForm.applyReason}")
     @Column(nullable = false)
     private String applyReason;
 }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ApplyForm.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ApplyForm.java
@@ -34,7 +34,7 @@ public class ApplyForm extends BaseEntity {
 
     private String memberId;
 
-    @Size(min = 1, max = 1000, message = "{size.applyForm.applyReason}")
     @Column(nullable = false)
+    @Size(min = 1, max = 1000, message = "{size.applyForm.applyReason}")
     private String applyReason;
 }

--- a/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
@@ -28,7 +28,6 @@ public class Application {
     private String address;
     private String interests;
     private String otherActivities;
-
     private String githubUrl;
     private ApplicationType applicationType;
     private Boolean isPass;

--- a/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
@@ -1,5 +1,6 @@
 package page.clab.api.domain.hiring.application.domain;
 
+import jakarta.persistence.Column;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -30,6 +31,7 @@ public class Application {
     private String interests;
 
     @Size(min = 1, max = 1000, message = "{size.application.otherActivities}")
+    @Column(nullable = false)
     private String otherActivities;
 
     private String githubUrl;

--- a/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
@@ -1,5 +1,6 @@
 package page.clab.api.domain.hiring.application.domain;
 
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,7 +28,10 @@ public class Application {
     private LocalDate birth;
     private String address;
     private String interests;
+
+    @Size(min = 1, max = 1000, message = "{size.application.otherActivities}")
     private String otherActivities;
+
     private String githubUrl;
     private ApplicationType applicationType;
     private Boolean isPass;

--- a/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
+++ b/src/main/java/page/clab/api/domain/hiring/application/domain/Application.java
@@ -1,7 +1,5 @@
 package page.clab.api.domain.hiring.application.domain;
 
-import jakarta.persistence.Column;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,9 +27,6 @@ public class Application {
     private LocalDate birth;
     private String address;
     private String interests;
-
-    @Size(min = 1, max = 1000, message = "{size.application.otherActivities}")
-    @Column(nullable = false)
     private String otherActivities;
 
     private String githubUrl;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -10,6 +10,7 @@ size.application.email=이메일을 {min}자 이상 입력하세요.
 size.application.department=학과를 {min}자 이상 입력하세요.
 size.application.address=주소를 {min}자 이상 입력하세요.
 size.application.otherActivities=활동 내용은 {min}자 이상 {max}자 이하로 입력하세요.
+size.applyForm.applyReason=지원동기는 {min}자 이상 {max}자 이하로 입력하세요.
 size.award.competitionName=대회 이름은 {min}자 이상 {max}자 이하로 입력하세요.
 size.award.organizer=주최 기관은 {min}자 이상 {max}자 이하로 입력하세요.
 size.award.awardName=수상명은 {min}자 이상 {max}자 이하로 입력하세요.


### PR DESCRIPTION
## Summary

> #542 

지원 동기 관련 글자 수 제한을 위한 수정 작업을 진행했습니다.

랜딩페이지의 모집공고에 지원하는 경우와 활동에 지원하는 경우 두 가지를 수정하였습니다.

## Tasks

- 활동 지원동기 1000자로 설정
- 랜딩페이지 모집공고 지원동기 1000자로 설정

## ETC
**칼럼 제약 사항 수정 쿼리문**
```
ALTER TABLE application
ALTER COLUMN other_activities TYPE VARCHAR(1000),
ALTER COLUMN other_activities SET NOT NULL;

ALTER TABLE apply_form
ALTER COLUMN apply_reason TYPE VARCHAR(1000);
```
