### PR TITLE
refactor: 활동 그룹 커리큘럼 글자 수 조정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ActivityGroup.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/domain/ActivityGroup.java
@@ -64,7 +64,7 @@ public class ActivityGroup extends BaseEntity {
     private String imageUrl;
 
     @Column(length = 1000)
-    @Size(min = 1, max = 1000, message = "{size.activityGroup.curriculum}")
+    @Size(max = 1000, message = "{size.activityGroup.curriculum}")
     private String curriculum;
 
     private LocalDate startDate;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,7 +1,7 @@
 size.accuse.reason=신고 사유는 {min}자 이상 {max}자 이하로 입력하세요.
 size.activityGroup.name=이름은 {min}자 이상 {max}자 이하로 입력하세요.
 size.activityGroup.content=내용은 {min}자 이상 {max}자 이하로 입력하세요.
-size.activityGroup.curriculum=커리큘럼은 {max}자 이하 입력하세요.
+size.activityGroup.curriculum=커리큘럼은 {max}자 이하로 입력하세요.
 size.activityGroupBoard.title=제목은 {min}자 이상 {max}자 이하로 입력하세요.
 size.application.studentId=학번은 {min}자 이상 {max}자 이하로 입력하세요.
 size.application.name=이름은 {min}자 이상 {max}자 이하로 입력하세요.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,7 +1,7 @@
 size.accuse.reason=신고 사유는 {min}자 이상 {max}자 이하로 입력하세요.
 size.activityGroup.name=이름은 {min}자 이상 {max}자 이하로 입력하세요.
 size.activityGroup.content=내용은 {min}자 이상 {max}자 이하로 입력하세요.
-size.activityGroup.curriculum=커리큘럼은 {min}자 이상 {max}자 이하로 입력하세요.
+size.activityGroup.curriculum=커리큘럼은 {max}자 이하 입력하세요.
 size.activityGroupBoard.title=제목은 {min}자 이상 {max}자 이하로 입력하세요.
 size.application.studentId=학번은 {min}자 이상 {max}자 이하로 입력하세요.
 size.application.name=이름은 {min}자 이상 {max}자 이하로 입력하세요.


### PR DESCRIPTION
## Summary

> #548 

활동 그룹의 커리큘럼 글자 수 `min` 값을 제거했습니다.(`default = 0`)
따라서, 커리큘럼에 아무 것도 적지 않아도 정상적으로 그룹이 생성됩니다.

## Tasks

- `curriculum` 필드의 `size`어노테이션 `min`값 제거

## ETC



## Screenshot

![image](https://github.com/user-attachments/assets/5f7949e1-08d2-4c3a-a24c-1d70028b5238)

