### PR TITLE
refactor: 활동 그룹 목록을 가장 최신에 생성된 순으로 정렬되도록 변경 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupMemberController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupMemberController.java
@@ -141,11 +141,9 @@ public class ActivityGroupMemberController {
     @GetMapping("/applied")
     public ApiResponse<PagedResponseDto<ActivityGroupStatusResponseDto>> getAppliedActivityGroups(
             @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "20") int size,
-            @RequestParam(name = "sortBy", defaultValue = "createdAt") List<String> sortBy,
-            @RequestParam(name = "sortDirection", defaultValue = "asc") List<String> sortDirection
-    ) throws InvalidColumnException, SortingArgumentException {
-        Pageable pageable = pageableUtils.createPageable(page, size, sortBy, sortDirection, ActivityGroupStatusResponseDto.class);
+            @RequestParam(name = "size", defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
         PagedResponseDto<ActivityGroupStatusResponseDto> activityGroups = activityGroupMemberService.getAppliedActivityGroups(pageable);
         return ApiResponse.success(activityGroups);
     }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupMemberController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupMemberController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -50,28 +49,34 @@ public class ActivityGroupMemberController {
         return ApiResponse.success(activityGroup);
     }
 
-    @Operation(summary = "[G] 나의 활동 목록 조회", description = "ROLE_GUEST 이상의 권한이 필요함")
+    @Operation(summary = "[G] 나의 활동 목록 조회", description = "ROLE_GUEST 이상의 권한이 필요함<br>" +
+            "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
     @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my")
     public ApiResponse<PagedResponseDto<ActivityGroupStatusResponseDto>> getMyActivityGroups(
             @RequestParam(name = "status", required = false) ActivityGroupStatus status,
             @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "20") int size
-    ) {
-        Pageable pageable = PageRequest.of(page, size);
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            @RequestParam(name = "sortBy", defaultValue = "createdAt") List<String> sortBy,
+            @RequestParam(name = "sortDirection", defaultValue = "desc") List<String> sortDirection
+    ) throws InvalidColumnException, SortingArgumentException {
+        Pageable pageable = pageableUtils.createPageable(page, size, sortBy, sortDirection, ActivityGroupStatusResponseDto.class);
         PagedResponseDto<ActivityGroupStatusResponseDto> activityGroups = activityGroupMemberService.getMyActivityGroups(status, pageable);
         return ApiResponse.success(activityGroups);
     }
 
-    @Operation(summary = "[U] 활동 상태별 조회", description = "ROLE_USER 이상의 권한이 필요함")
+    @Operation(summary = "[U] 활동 상태별 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+            "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/status")
     public ApiResponse<PagedResponseDto<ActivityGroupStatusResponseDto>> getActivityGroupsByStatus(
             @RequestParam(name = "activityGroupStatus") ActivityGroupStatus status,
             @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "20") int size
-    ) {
-        Pageable pageable = PageRequest.of(page, size);
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            @RequestParam(name = "sortBy", defaultValue = "createdAt") List<String> sortBy,
+            @RequestParam(name = "sortDirection", defaultValue = "desc") List<String> sortDirection
+    ) throws InvalidColumnException, SortingArgumentException {
+        Pageable pageable = pageableUtils.createPageable(page, size, sortBy, sortDirection, ActivityGroupStatusResponseDto.class);
         PagedResponseDto<ActivityGroupStatusResponseDto> activityGroups = activityGroupMemberService.getActivityGroupsByStatus(status, pageable);
         return ApiResponse.success(activityGroups);
     }
@@ -136,14 +141,17 @@ public class ActivityGroupMemberController {
         return ApiResponse.success(id);
     }
     
-    @Operation(summary = "[U] 내가 지원한 활동 목록 조회", description = "ROLE_USER 이상의 권한이 필요함")
+    @Operation(summary = "[U] 내가 지원한 활동 목록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+            "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
     @PreAuthorize("hasRole('USER')")
     @GetMapping("/applied")
     public ApiResponse<PagedResponseDto<ActivityGroupStatusResponseDto>> getAppliedActivityGroups(
             @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "20") int size
-    ) {
-        Pageable pageable = PageRequest.of(page, size);
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            @RequestParam(name = "sortBy", defaultValue = "createdAt") List<String> sortBy,
+            @RequestParam(name = "sortDirection", defaultValue = "desc") List<String> sortDirection
+    ) throws InvalidColumnException, SortingArgumentException {
+        Pageable pageable = pageableUtils.createPageable(page, size, sortBy, sortDirection, ActivityGroupStatusResponseDto.class);
         PagedResponseDto<ActivityGroupStatusResponseDto> activityGroups = activityGroupMemberService.getAppliedActivityGroups(pageable);
         return ApiResponse.success(activityGroups);
     }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -94,7 +94,6 @@ public class ActivityGroupMemberService {
                 .toList();
 
         List<ActivityGroup> paginatedActivityGroups = activityGroups.stream()
-                .sorted(Comparator.comparing(ActivityGroup::getCreatedAt).reversed())
                 .skip(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .toList();
@@ -172,7 +171,6 @@ public class ActivityGroupMemberService {
                 .map(GroupMember::getActivityGroup)
                 .filter(ActivityGroup::isProgressing)
                 .distinct()
-                .sorted(Comparator.comparing(ActivityGroup::getCreatedAt).reversed())
                 .map(this::getActivityGroupStatusResponseDto)
                 .toList();
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -42,7 +42,6 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -95,6 +94,7 @@ public class ActivityGroupMemberService {
                 .toList();
 
         List<ActivityGroup> paginatedActivityGroups = activityGroups.stream()
+                .sorted(Comparator.comparing(ActivityGroup::getCreatedAt).reversed())
                 .skip(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .toList();
@@ -172,6 +172,7 @@ public class ActivityGroupMemberService {
                 .map(GroupMember::getActivityGroup)
                 .filter(ActivityGroup::isProgressing)
                 .distinct()
+                .sorted(Comparator.comparing(ActivityGroup::getCreatedAt).reversed())
                 .map(this::getActivityGroupStatusResponseDto)
                 .toList();
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepositoryCustomImpl.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepositoryCustomImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroup;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupStatus;
 import page.clab.api.domain.activity.activitygroup.domain.QActivityGroup;
+import page.clab.api.global.util.OrderSpecifierUtil;
 
 import java.util.List;
 
@@ -28,7 +29,7 @@ public class ActivityGroupRepositoryCustomImpl implements ActivityGroupRepositor
 
         List<ActivityGroup> activityGroups = queryFactory.selectFrom(qActivityGroup)
                 .where(builder)
-                .orderBy(qActivityGroup.createdAt.desc())
+                .orderBy(OrderSpecifierUtil.getOrderSpecifiers(pageable, qActivityGroup))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepositoryCustomImpl.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupRepositoryCustomImpl.java
@@ -28,6 +28,7 @@ public class ActivityGroupRepositoryCustomImpl implements ActivityGroupRepositor
 
         List<ActivityGroup> activityGroups = queryFactory.selectFrom(qActivityGroup)
                 .where(builder)
+                .orderBy(qActivityGroup.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();


### PR DESCRIPTION
## Summary

> #549 

`나의 활동 목록 조회`, `활동 상태별 조회`, `내가 지원한 활동 목록 조회` api 의 응답인 활동 그룹 목록의 정렬을 아래와 같이 변경했습니다.
- 정렬 기준 : `createdAt`
- 정렬 방향 : `desc` 
 
## Tasks

- 활동 그룹 목록을 반환하는 api들의 응답값을 `createdAt` 기준 `desc` 방향으로 정렬

## ETC

수정 전과 수정 후의 response 값을 기록했었는데, 테스트했던 response 값이 길어 Screenshot이 아닌 텍스트 형식으로 기록했습니다.

## Screenshot

- 내가 지원한 활동 목록 조회 (수정 전)
```json
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 2,
    "take": 2,
    "items": [
      {
        "id": 6,
        "name": "게임 스터디",
        "content": "게임 스터디",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "202014941",
            "name": "송재훈"
          },
          {
            "id": "202500001",
            "name": "설윤"
          }
        ],
        "participantCount": 5,
        "weeklyActivityCount": 1,
        "createdAt": "2024-09-06T14:11:09.312321"
      },
      {
        "id": 7,
        "name": "test",
        "content": "test",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "leader",
            "name": "리더"
          }
        ],
        "participantCount": 1,
        "weeklyActivityCount": 0,
        "createdAt": "2024-09-07T12:36:44.223115"
      }
    ]
  }
}
```

- 내가 지원한 활동 목록 조회 (수정 후)
```json
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 2,
    "take": 2,
    "items": [
      {
        "id": 7,
        "name": "test",
        "content": "test",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "superuser",
            "name": "관리자"
          }
        ],
        "participantCount": 2,
        "weeklyActivityCount": 0,
        "createdAt": "2024-09-07T12:36:44.223115"
      },
      {
        "id": 6,
        "name": "게임 스터디",
        "content": "게임 스터디",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "202014941",
            "name": "송재훈"
          },
          {
            "id": "202500001",
            "name": "설윤"
          }
        ],
        "participantCount": 5,
        "weeklyActivityCount": 1,
        "createdAt": "2024-09-06T14:11:09.312321"
      }
    ]
  }
}
```
---

- 나의 활동 목록 조회 (수정 전)
```json
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 2,
    "take": 2,
    "items": [
      {
        "id": 6,
        "name": "게임 스터디",
        "content": "게임 스터디",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "202014941",
            "name": "송재훈"
          },
          {
            "id": "202500001",
            "name": "설윤"
          }
        ],
        "participantCount": 5,
        "weeklyActivityCount": 1,
        "createdAt": "2024-09-06T14:11:09.312321"
      },
      {
        "id": 7,
        "name": "test",
        "content": "test",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "leader",
            "name": "리더"
          }
        ],
        "participantCount": 2,
        "weeklyActivityCount": 0,
        "createdAt": "2024-09-07T12:36:44.223115"
      }
    ]
  }
}
```

- 나의 활동 목록 조회 (수정 후)
```json
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 3,
    "take": 3,
    "items": [
      {
        "id": 11,
        "name": "러브 스터디",
        "content": "러브 스터디",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "202500001",
            "name": "설윤"
          }
        ],
        "participantCount": 1,
        "weeklyActivityCount": 0,
        "createdAt": "2024-09-12T21:39:27.817431"
      },
      {
        "id": 7,
        "name": "test",
        "content": "test",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "leader",
            "name": "리더"
          }
        ],
        "participantCount": 2,
        "weeklyActivityCount": 0,
        "createdAt": "2024-09-07T12:36:44.223115"
      },
      {
        "id": 6,
        "name": "게임 스터디",
        "content": "게임 스터디",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "202014941",
            "name": "송재훈"
          },
          {
            "id": "202500001",
            "name": "설윤"
          }
        ],
        "participantCount": 5,
        "weeklyActivityCount": 1,
        "createdAt": "2024-09-06T14:11:09.312321"
      }
    ]
  }
}
```
---

- 활동 상태별 조회 (수정 전)
```json
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 3,
    "take": 3,
    "items": [
      {
        "id": 4,
        "name": "2024-1 신입생 대상 C언어 스터디",
        "content": "2024-1 신입생 대상 C언어 스터디",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "leader",
            "name": "리더"
          },
          {
            "id": "201610000",
            "name": "김민정"
          }
        ],
        "participantCount": 4,
        "weeklyActivityCount": 1,
        "createdAt": "2024-08-25T23:54:34.881528"
      },
      {
        "id": 8,
        "name": "test2",
        "content": "test2",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "leader",
            "name": "리더"
          }
        ],
        "participantCount": 1,
        "weeklyActivityCount": 0,
        "createdAt": "2024-09-07T12:36:52.529044"
      },
      {
        "id": 10,
        "name": "test4",
        "content": "test4",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "leader",
            "name": "리더"
          }
        ],
        "participantCount": 1,
        "weeklyActivityCount": 0,
        "createdAt": "2024-09-07T12:37:07.080174"
      }
    ]
  }
}
```

- 활동 상태별 조회 (수정 후)
```json
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 3,
    "take": 3,
    "items": [
      {
        "id": 10,
        "name": "test4",
        "content": "test4",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "leader",
            "name": "리더"
          }
        ],
        "participantCount": 1,
        "weeklyActivityCount": 0,
        "createdAt": "2024-09-07T12:37:07.080174"
      },
      {
        "id": 8,
        "name": "test2",
        "content": "test2",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "leader",
            "name": "리더"
          }
        ],
        "participantCount": 1,
        "weeklyActivityCount": 0,
        "createdAt": "2024-09-07T12:36:52.529044"
      },
      {
        "id": 4,
        "name": "2024-1 신입생 대상 C언어 스터디",
        "content": "2024-1 신입생 대상 C언어 스터디",
        "category": "STUDY",
        "subject": "1학년 이상",
        "imageUrl": "https://i.namu.wiki/i/KcqDuQYTxNpUcLIMZTg28QXse0XiWx1G7K68kYYCo1GuhoHmhB_V8Qe9odGGt0BH9-0nQZTN53WXTNpDmwVfWQ.svg",
        "leaders": [
          {
            "id": "leader",
            "name": "리더"
          },
          {
            "id": "201610000",
            "name": "김민정"
          }
        ],
        "participantCount": 4,
        "weeklyActivityCount": 1,
        "createdAt": "2024-08-25T23:54:34.881528"
      }
    ]
  }
}
```

