### PR TITLE
refactor: 활동 상세 조회 응답에서 실제 참여인원만 반환하도록 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupDetailsRepositoryImpl.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupDetailsRepositoryImpl.java
@@ -29,7 +29,8 @@ public class ActivityGroupDetailsRepositoryImpl implements ActivityGroupDetailsR
         QActivityGroupBoard qActivityGroupBoard = QActivityGroupBoard.activityGroupBoard;
 
         BooleanBuilder groupMemberCondition = new BooleanBuilder();
-        if (activityGroupId != null) groupMemberCondition.and(qGroupMember.activityGroup.id.eq(activityGroupId).and(qGroupMember.status.eq(GroupMemberStatus.ACCEPTED)));
+        if (activityGroupId != null) groupMemberCondition.and(qGroupMember.activityGroup.id.eq(activityGroupId)
+                .and(qGroupMember.status.eq(GroupMemberStatus.ACCEPTED)));
 
         List<GroupMember> groupMembers = queryFactory.selectFrom(qGroupMember)
                 .where(groupMemberCondition)

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupDetailsRepositoryImpl.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/ActivityGroupDetailsRepositoryImpl.java
@@ -8,6 +8,7 @@ import page.clab.api.domain.activity.activitygroup.domain.ActivityGroup;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupBoard;
 import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupBoardCategory;
 import page.clab.api.domain.activity.activitygroup.domain.GroupMember;
+import page.clab.api.domain.activity.activitygroup.domain.GroupMemberStatus;
 import page.clab.api.domain.activity.activitygroup.domain.QActivityGroup;
 import page.clab.api.domain.activity.activitygroup.domain.QActivityGroupBoard;
 import page.clab.api.domain.activity.activitygroup.domain.QGroupMember;
@@ -28,7 +29,7 @@ public class ActivityGroupDetailsRepositoryImpl implements ActivityGroupDetailsR
         QActivityGroupBoard qActivityGroupBoard = QActivityGroupBoard.activityGroupBoard;
 
         BooleanBuilder groupMemberCondition = new BooleanBuilder();
-        if (activityGroupId != null) groupMemberCondition.and(qGroupMember.activityGroup.id.eq(activityGroupId));
+        if (activityGroupId != null) groupMemberCondition.and(qGroupMember.activityGroup.id.eq(activityGroupId).and(qGroupMember.status.eq(GroupMemberStatus.ACCEPTED)));
 
         List<GroupMember> groupMembers = queryFactory.selectFrom(qGroupMember)
                 .where(groupMemberCondition)


### PR DESCRIPTION
## Summary

> #552 

활동 상세 조회 API에서 groupMembers를 담아서 반환할 때 실제로 참여중인 멤버만 반환하도록 수정하였습니다.

## Tasks

- 활동 상세 조회 시 ACCEPTED인 멤버만 groupMembers에 담도록 수정

## Screenshot
- 수정하고자 하는 메소드가 활동 상세 조회 시에만 사용되고 있음을 확인했습니다. 혹시 다른 API의 응답 생성 시 영향을 미칠까봐 확인하였어요.
![image](https://github.com/user-attachments/assets/262336bd-2b77-41df-a4f5-469f01a4775a)

- NONE이고 WATING인 멤버는 응답에 포함되지 않습니다.
![image](https://github.com/user-attachments/assets/1f05b84a-568f-423c-957a-e5a24d63e9e5)

- MEMBER이고 REJECTED된 멤버는 즉 활동하다가 퇴출된 멤버는 응답에 포함되지 않습니다.
![image](https://github.com/user-attachments/assets/e2c9b026-1245-4d22-81c5-dc6bbfdfb9e7)

-ACCEPTED인 멤버만 응답에 포함됩니다.
![image](https://github.com/user-attachments/assets/fd5bc72d-d92d-4681-bf3a-de69c12c6df9)


