### PR TITLE
refactor: 활동 3차 QA에 따른 활동 그룹 관련 기능 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -215,8 +215,9 @@ public class ActivityGroupAdminService {
     }
 
     public boolean isMemberGroupLeaderRole(ActivityGroup activityGroup, Member member) {
-        GroupMember groupMember = activityGroupMemberService.getGroupMemberByActivityGroupAndMemberOrThrow(activityGroup, member.getId());
-        return groupMember.isLeader() || member.isAdminRole();
+        return activityGroupMemberService.getGroupMemberByActivityGroupAndMember(activityGroup, member.getId())
+                .map(GroupMember::isLeader)
+                .orElse(member.isAdminRole());
     }
 
     public boolean isMemberGroupLeaderRole(Long activityGroupId, String memberId) {

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -217,7 +217,7 @@ public class ActivityGroupAdminService {
     public boolean isMemberGroupLeaderRole(ActivityGroup activityGroup, Member member) {
         return activityGroupMemberService.getGroupMemberByActivityGroupAndMember(activityGroup, member.getId())
                 .map(GroupMember::isLeader)
-                .orElse(member.isAdminRole());
+                .orElseGet(member::isAdminRole);
     }
 
     public boolean isMemberGroupLeaderRole(Long activityGroupId, String memberId) {

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -70,7 +70,7 @@ public class ActivityGroupAdminService {
     public Long updateActivityGroup(Long activityGroupId, ActivityGroupUpdateRequestDto requestDto) throws PermissionDeniedException {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);
-        validateLeaderPermission(activityGroup, currentMember, "해당 활동을 수정할 권한이 없습니다.");
+        validateLeaderOrAdminPermission(activityGroup, currentMember, "해당 활동을 수정할 권한이 없습니다.");
         activityGroup.update(requestDto);
         return activityGroupRepository.save(activityGroup).getId();
     }
@@ -102,7 +102,7 @@ public class ActivityGroupAdminService {
         List<GroupMember> groupLeaders = activityGroupMemberService.getGroupMemberByActivityGroupIdAndRole(activityGroupId, ActivityGroupRole.LEADER);
 
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
-        validateLeaderPermission(activityGroup, currentMember, "해당 활동을 삭제할 권한이 없습니다.");
+        validateLeaderOrAdminPermission(activityGroup, currentMember, "해당 활동을 삭제할 권한이 없습니다.");
 
         activityGroupMemberService.deleteAll(groupMembers);
         groupScheduleRepository.deleteAll(groupSchedules);
@@ -118,7 +118,7 @@ public class ActivityGroupAdminService {
     public Long updateProjectProgress(Long activityGroupId, Long progress) throws PermissionDeniedException {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);
-        validateLeaderPermission(activityGroup, currentMember, "해당 활동을 수정할 권한이 업습니다.");
+        validateLeaderOrAdminPermission(activityGroup, currentMember, "해당 활동을 수정할 권한이 업습니다.");
         activityGroup.updateProgress(progress);
         return activityGroupRepository.save(activityGroup).getId();
     }
@@ -127,7 +127,7 @@ public class ActivityGroupAdminService {
     public Long addSchedule(Long activityGroupId, List<GroupScheduleDto> scheduleDtos) throws PermissionDeniedException {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);
-        validateLeaderPermission(activityGroup, currentMember, "해당 일정을 등록할 권한이 없습니다.");
+        validateLeaderOrAdminPermission(activityGroup, currentMember, "해당 일정을 등록할 권한이 없습니다.");
         List<GroupSchedule> groupSchedules = scheduleDtos.stream()
                 .map(scheduleDto -> GroupScheduleDto.toEntity(scheduleDto, activityGroup))
                 .toList();
@@ -139,7 +139,7 @@ public class ActivityGroupAdminService {
     public PagedResponseDto<ActivityGroupMemberWithApplyReasonResponseDto> getGroupMembersWithApplyReason(Long activityGroupId, Pageable pageable) throws PermissionDeniedException {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);
-        validateLeaderPermission(activityGroup, currentMember, "해당 활동의 멤버를 조회할 권한이 없습니다.");
+        validateLeaderOrAdminPermission(activityGroup, currentMember, "해당 활동의 멤버를 조회할 권한이 없습니다.");
 
         List<ApplyForm> applyForms = applyFormRepository.findAllByActivityGroup(activityGroup);
         Map<String, String> memberIdToApplyReasonMap = applyForms.stream()
@@ -165,7 +165,7 @@ public class ActivityGroupAdminService {
     public Long manageGroupMemberStatus(Long activityGroupId, List<String> memberIds, GroupMemberStatus status) throws PermissionDeniedException {
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
         ActivityGroup activityGroup = getActivityGroupByIdOrThrow(activityGroupId);
-        validateLeaderPermission(activityGroup, currentMember, "해당 활동의 신청 멤버를 조회할 권한이 없습니다.");
+        validateLeaderOrAdminPermission(activityGroup, currentMember, "해당 활동의 신청 멤버를 조회할 권한이 없습니다.");
         memberIds.forEach(memberId -> updateGroupMemberStatus(memberId, status, activityGroup));
         return activityGroup.getId();
     }
@@ -176,7 +176,7 @@ public class ActivityGroupAdminService {
         GroupMember groupMember = activityGroupMemberService.getGroupMemberByActivityGroupAndMemberOrThrow(activityGroup, memberId);
         Member currentMember = externalRetrieveMemberUseCase.getCurrentMember();
 
-        validateLeaderPermission(activityGroup, currentMember, "해당 활동의 멤버 직책을 변경할 권한이 없습니다.");
+        validateLeaderOrAdminPermission(activityGroup, currentMember, "해당 활동의 멤버 직책을 변경할 권한이 없습니다.");
         validateLeaderRoleChange(activityGroup, groupMember);
         validateMemberIsActive(groupMember);
         validateNewPosition(groupMember, position);
@@ -214,7 +214,7 @@ public class ActivityGroupAdminService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 활동입니다."));
     }
 
-    public boolean isMemberGroupLeaderRole(ActivityGroup activityGroup, Member member) {
+    public boolean hasLeaderOrAdminRole(ActivityGroup activityGroup, Member member) {
         return activityGroupMemberService.getGroupMemberByActivityGroupAndMember(activityGroup, member.getId())
                 .map(GroupMember::isLeader)
                 .orElseGet(member::isAdminRole);
@@ -256,8 +256,8 @@ public class ActivityGroupAdminService {
         return activityGroup;
     }
 
-    private void validateLeaderPermission(ActivityGroup activityGroup, Member member, String message) throws PermissionDeniedException {
-        if (!isMemberGroupLeaderRole(activityGroup, member)) {
+    private void validateLeaderOrAdminPermission(ActivityGroup activityGroup, Member member, String message) throws PermissionDeniedException {
+        if (!hasLeaderOrAdminRole(activityGroup, member)) {
             throw new PermissionDeniedException(message);
         }
     }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupBoardService.java
@@ -89,7 +89,7 @@ public class ActivityGroupBoardService {
                                                  category.isFeedback();
 
         // NOTICE, WEEKLY_ACTIVITY, ASSIGNMENT, FEEDBACK 카테고리에서 권한이 ADMIN 이상이 아니거나, 리더가 아니면 예외처리
-        if (isRequireAdminOrLeaderCategory && !(role.isHigherThanOrEqual(Role.ADMIN) || activityGroupAdminService.isMemberGroupLeaderRole(activityGroup, currentMember))) {
+        if (isRequireAdminOrLeaderCategory && !(role.isHigherThanOrEqual(Role.ADMIN) || activityGroupAdminService.hasLeaderOrAdminRole(activityGroup, currentMember))) {
             throw new PermissionDeniedException("해당 카테고리에서 게시글을 작성할 권한이 없습니다.");
         }
     }
@@ -104,7 +104,7 @@ public class ActivityGroupBoardService {
 
     private boolean isSubmitterOrLeader(ActivityGroup activityGroup, ActivityGroupBoard board, Member currentMember) {
         boolean isSubmitter = board.getMemberId().equals(currentMember.getId());
-        boolean isLeader = activityGroupAdminService.isMemberGroupLeaderRole(activityGroup, currentMember);
+        boolean isLeader = activityGroupAdminService.hasLeaderOrAdminRole(activityGroup, currentMember);
         // FEEDBACK을 가져오기 위해, parent의 카테고리가 SUBMIT이고, 현재 로그인한 멤버인지 확인
         if (board.getCategory().isFeedback()) {
             ActivityGroupBoard parentBoard = board.getParent();

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -42,6 +42,7 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -213,6 +214,10 @@ public class ActivityGroupMemberService {
                         groupMember -> groupMember.getActivityGroup().getId(),
                         Function.identity()
                 ));
+    }
+
+    public Optional<GroupMember> getGroupMemberByActivityGroupAndMember(ActivityGroup activityGroup, String memberId) {
+        return groupMemberRepository.findByActivityGroupAndMemberId(activityGroup, memberId);
     }
 
     public GroupMember getGroupMemberByActivityGroupAndMemberOrThrow(ActivityGroup activityGroup, String memberId) {


### PR DESCRIPTION
## Summary

> #561 

활동 삭제시 활동에 참여하지 않은 admin도 삭제가 가능하도록 변경했습니다.

## Tasks

- 활동에 참여하지 않은 admin과 해당 활동의 Leader가 활동 삭제를 할 수 있도록 변경

## ETC

활동 삭제 시 사용하던 `validateLeaderPermission()`메서드에서 `GroupLeader`를 조회할 때 활동에 참여하지 않은 `admin`일 경우 `NotFoundException`을 던졌었는데, `validateLeaderPermission()`을 변경하게 되면서 연관되어 있던 다른 메서드의 권한 검사도 변경되게 되었습니다.
변경된 기능은 다음과 같습니다.
- 활동 수정, 활동 삭제, 프로젝트 진행 수정, 일정 등록, 활동 멤버 지원서 조회, 멤버 상태 변경, 멤버 직책 변경 
위의 기능들은 전부 admin도 가능해야 할 일이라고 생각되어 변경된 상태로 놔뒀는데, 잘 살펴봐주시면 감사하겠습니다.

## Screenshot
