### PR TITLE
refactor: 3차 QA에 따른 활동 관련 알림 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -206,7 +206,7 @@ public class ActivityGroupAdminService {
         groupMember.validateAccessPermission();
         groupMember.updateStatus(status);
         activityGroupMemberService.save(groupMember);
-        externalSendNotificationUseCase.sendNotificationToMember(member.getId(), "활동 그룹 신청이 [" + status.getDescription() + "] 상태로 변경되었습니다.");
+        externalSendNotificationUseCase.sendNotificationToMember(member.getId(), "[" + activityGroup.getName() + "]" + " 신청이 [" + status.getDescription() + "] 상태로 변경되었습니다.");
     }
 
     public ActivityGroup getActivityGroupByIdOrThrow(Long activityGroupId) {


### PR DESCRIPTION
## Summary

> #562 

활동에 신청한 멤버의 상태를 변경할 경우, 해당 멤버에게 알림이 가는 로직이 있습니다.
이때 기존에는 어떤 활동인지 활동명이 명시되지 않아 불편하여 활동명을 알림 문구에
추가하는 작업을 진행했습니다.

## Tasks

- 스터디 거절과 승인 시 어떤 스터디 인지 알림에 명시

## ETC

@Jeong-Ag님과 @SongJaeHoonn님과 상의해서 알림 문구를 수정하였습니다!

## Screenshot

- 기존 알림 문구
![image](https://github.com/user-attachments/assets/3a8081bc-1cbd-43f9-bf97-2c1c4578e80f)
- 개선된 알림 문구
![image](https://github.com/user-attachments/assets/f05d1848-71f5-45cb-91de-c1b33ba08e7b)


