### PR TITLE
refactor: 이달의 생일자 조회 API 정렬 로직 개선 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepositoryImpl.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepositoryImpl.java
@@ -84,7 +84,6 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         return new PageImpl<>(members, pageable, total);
     }
 
-
     @Override
     public Page<MemberJpaEntity> findMemberRoleInfoByConditions(String memberId, String memberName, Role role, Pageable pageable) {
         QMemberJpaEntity member = QMemberJpaEntity.memberJpaEntity;

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepositoryImpl.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepositoryImpl.java
@@ -1,16 +1,22 @@
 package page.clab.api.domain.memberManagement.member.adapter.out.persistence;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import page.clab.api.domain.memberManagement.member.domain.Role;
 import page.clab.api.global.util.OrderSpecifierUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Repository
@@ -46,10 +52,26 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     public Page<MemberJpaEntity> findBirthdaysThisMonth(int month, Pageable pageable) {
         QMemberJpaEntity qMember = QMemberJpaEntity.memberJpaEntity;
 
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+        for (Sort.Order order : pageable.getSort()) {
+            String property = order.getProperty();
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            if ("birth".equals(property)) {
+                OrderSpecifier<?> dayOrderSpecifier = new OrderSpecifier<>(
+                        direction,
+                        Expressions.numberTemplate(Integer.class, "day({0})", qMember.birth)
+                );
+                orderSpecifiers.add(dayOrderSpecifier);
+            } else {
+                PathBuilder<Object> path = new PathBuilder<>(qMember.getType(), qMember.getMetadata());
+                orderSpecifiers.add(new OrderSpecifier(direction, path.get(property)));
+            }
+        }
+
         List<MemberJpaEntity> members = queryFactory
                 .selectFrom(qMember)
                 .where(birthdayInMonth(month))
-                .orderBy(OrderSpecifierUtil.getOrderSpecifiers(pageable, qMember))
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -61,6 +83,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
 
         return new PageImpl<>(members, pageable, total);
     }
+
 
     @Override
     public Page<MemberJpaEntity> findMemberRoleInfoByConditions(String memberId, String memberName, Role role, Pageable pageable) {


### PR DESCRIPTION
## Summary

> #570

이달의 생일자 조회 API에서 정렬 기준에 `birth`가 있는 경우 년도와 월을 무시하고 `일`을 기준으로 정렬하는 로직을 개선했습니다. 기존에는 `yyyy-MM-dd` 형식으로 정렬되었기 때문에 년도에 의해 조회 결과가 의도와 다르게 나왔으나, 이번 수정에서는 `일`을 기준으로 정확하게 정렬되도록 변경했습니다.

## Tasks

- 정렬 기준이 birth인 경우 `일`을 기준으로 정렬하도록 설정
- 정렬 기준이 여러 개인 경우 정렬 순서를 보장

## Response Example (JSON)
```json
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 7,
    "take": 7,
    "items": [
      {
        "id": "202310000",
        "name": "홍길동",
        "birth": "2004-01-01",
        "imageUrl": "https://www.clab.page/assets/dongmin-860f3a1e.jpeg"
      },
      {
        "id": "202112000",
        "name": "홍길동",
        "birth": "2000-01-01",
        "imageUrl": null
      },
      {
        "id": "201912156",
        "name": "홍길동",
        "birth": "2004-01-07",
        "imageUrl": "https://www.clab.page/assets/dongmin-860f3a1e.jpeg"
      },
      {
        "id": "202310001",
        "name": "홍길동",
        "birth": "2004-01-09",
        "imageUrl": "https://www.clab.page/assets/dongmin-860f3a1e.jpeg"
      },
      {
        "id": "202312111",
        "name": "홍길동",
        "birth": "2004-01-10",
        "imageUrl": ""
      },
      {
        "id": "202310011",
        "name": "홍길동",
        "birth": "2004-01-11",
        "imageUrl": "https://www.clab.page/assets/dongmin-860f3a1e.jpeg"
      },
      {
        "id": "202312000",
        "name": "홍길동",
        "birth": "2004-01-21",
        "imageUrl": ""
      }
    ]
  }
}
```