### PR TITLE
refactor: 활동 멤버 및 지원서 조회 정렬 로직 변경 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/api/ActivityGroupAdminController.java
@@ -118,7 +118,7 @@ public class ActivityGroupAdminController {
             @RequestParam(name = "activityGroupId") Long activityGroupId,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,
-            @RequestParam(name = "sortBy", defaultValue = "memberId") List<String> sortBy,
+            @RequestParam(name = "sortBy", defaultValue = "status") List<String> sortBy,
             @RequestParam(name = "sortDirection", defaultValue = "asc") List<String> sortDirection
     ) throws SortingArgumentException, PermissionDeniedException, InvalidColumnException {
         Pageable pageable = pageableUtils.createPageable(page, size, sortBy, sortDirection, ActivityGroupMemberWithApplyReasonResponseDto.class);

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -2,6 +2,7 @@ package page.clab.api.domain.activity.activitygroup.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -146,8 +147,8 @@ public class ActivityGroupAdminService {
                         ApplyForm::getApplyReason
                 ));
 
-        List<GroupMember> groupMembers = activityGroupMemberService.getGroupMemberByActivityGroupId(activityGroupId);
-        List<ActivityGroupMemberWithApplyReasonResponseDto> groupMembersWithApplyReason = groupMembers.stream()
+        Page<GroupMember> groupMembers = activityGroupMemberService.getGroupMemberByActivityGroupId(activityGroupId, pageable);
+        List<ActivityGroupMemberWithApplyReasonResponseDto> groupMembersWithApplyReason = groupMembers.getContent().stream()
                 .map(groupMember -> {
                     String applyReason = memberIdToApplyReasonMap.getOrDefault(groupMember.getMemberId(), "");
                     Member member = externalRetrieveMemberUseCase.findByIdOrThrow(groupMember.getMemberId());
@@ -155,7 +156,8 @@ public class ActivityGroupAdminService {
                 })
                 .toList();
 
-        return new PagedResponseDto<>(groupMembersWithApplyReason, pageable, true);
+        Page<ActivityGroupMemberWithApplyReasonResponseDto> paginatedGroupMembersWithApplyReason = new PageImpl<>(groupMembersWithApplyReason, pageable, groupMembers.getTotalElements());
+        return new PagedResponseDto<>(paginatedGroupMembersWithApplyReason, groupMembers.getTotalElements(), groupMembersWithApplyReason.size());
     }
 
     @Transactional

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupAdminService.java
@@ -35,7 +35,6 @@ import page.clab.api.global.exception.NotFoundException;
 import page.clab.api.global.exception.PermissionDeniedException;
 
 import java.time.LocalDate;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -154,15 +153,9 @@ public class ActivityGroupAdminService {
                     Member member = externalRetrieveMemberUseCase.findByIdOrThrow(groupMember.getMemberId());
                     return ActivityGroupMemberWithApplyReasonResponseDto.create(member, groupMember, applyReason);
                 })
-                .sorted(Comparator.comparing(ActivityGroupMemberWithApplyReasonResponseDto::getStatus))
                 .toList();
 
-        List<ActivityGroupMemberWithApplyReasonResponseDto> paginatedMembersWithApplyReason = groupMembersWithApplyReason.stream()
-                .skip(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .toList();
-
-        return new PagedResponseDto<>(paginatedMembersWithApplyReason, groupMembersWithApplyReason.size(), pageable);
+        return new PagedResponseDto<>(groupMembersWithApplyReason, pageable, true);
     }
 
     @Transactional

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -227,6 +227,10 @@ public class ActivityGroupMemberService {
         return groupMemberRepository.findAllByActivityGroupIdOrderByMemberIdAsc(activityGroupId);
     }
 
+    public Page<GroupMember> getGroupMemberByActivityGroupId(Long activityGroupId, Pageable pageable) {
+        return groupMemberRepository.findAllByActivityGroupId(activityGroupId, pageable);
+    }
+
     public List<GroupMember> getGroupMemberByActivityGroupIdAndStatus(Long activityGroupId, GroupMemberStatus status) {
         return groupMemberRepository.findAllByActivityGroupIdAndStatus(activityGroupId, status);
     }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -94,16 +94,11 @@ public class ActivityGroupMemberService {
                 .distinct()
                 .toList();
 
-        List<ActivityGroup> paginatedActivityGroups = activityGroups.stream()
-                .skip(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .toList();
-
-        List<ActivityGroupStatusResponseDto> activityGroupDtos = paginatedActivityGroups.stream()
+        List<ActivityGroupStatusResponseDto> activityGroupDtos = activityGroups.stream()
                 .map(this::getActivityGroupStatusResponseDto)
                 .toList();
 
-        return new PagedResponseDto<>(activityGroupDtos, activityGroups.size(), pageable);
+        return new PagedResponseDto<>(activityGroupDtos, pageable);
     }
 
     @Transactional(readOnly = true)
@@ -175,12 +170,7 @@ public class ActivityGroupMemberService {
                 .map(this::getActivityGroupStatusResponseDto)
                 .toList();
 
-        List<ActivityGroupStatusResponseDto> paginatedActivityGroups = activityGroups.stream()
-                .skip(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .toList();
-
-        return new PagedResponseDto<>(paginatedActivityGroups, activityGroups.size(), pageable);
+        return new PagedResponseDto<>(activityGroups, pageable);
     }
 
     private ActivityGroupStatusResponseDto getActivityGroupStatusResponseDto(ActivityGroup activityGroup) {

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -37,6 +37,7 @@ import page.clab.api.external.memberManagement.member.application.port.ExternalR
 import page.clab.api.external.memberManagement.notification.application.port.ExternalSendNotificationUseCase;
 import page.clab.api.global.common.dto.PagedResponseDto;
 import page.clab.api.global.exception.NotFoundException;
+import page.clab.api.global.util.PaginationUtils;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -58,6 +59,7 @@ public class ActivityGroupMemberService {
     private final ActivityGroupDetailsRepository activityGroupDetailsRepository;
     private final ExternalRetrieveMemberUseCase externalRetrieveMemberUseCase;
     private final ExternalSendNotificationUseCase externalSendNotificationUseCase;
+    private final PaginationUtils paginationUtils;
 
     @Transactional(readOnly = true)
     public ActivityGroupDetailResponseDto getActivityGroup(Long activityGroupId) {
@@ -98,7 +100,9 @@ public class ActivityGroupMemberService {
                 .map(this::getActivityGroupStatusResponseDto)
                 .toList();
 
-        return new PagedResponseDto<>(activityGroupDtos, pageable);
+        List<ActivityGroupStatusResponseDto> paginatedActivityGroupDtos = paginationUtils.applySortingAndSlicing(activityGroupDtos, pageable);
+
+        return new PagedResponseDto<>(paginatedActivityGroupDtos, activityGroups.size(), pageable);
     }
 
     @Transactional(readOnly = true)
@@ -170,7 +174,9 @@ public class ActivityGroupMemberService {
                 .map(this::getActivityGroupStatusResponseDto)
                 .toList();
 
-        return new PagedResponseDto<>(activityGroups, pageable);
+        List<ActivityGroupStatusResponseDto> paginatedActivityGroups = paginationUtils.applySortingAndSlicing(activityGroups, pageable);
+
+        return new PagedResponseDto<>(paginatedActivityGroups, activityGroups.size(), pageable);
     }
 
     private ActivityGroupStatusResponseDto getActivityGroupStatusResponseDto(ActivityGroup activityGroup) {

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -237,10 +237,6 @@ public class ActivityGroupMemberService {
         return groupMemberRepository.findAllByActivityGroupIdOrderByMemberIdAsc(activityGroupId);
     }
 
-    public Page<GroupMember> getGroupMemberByActivityGroupId(Long activityGroupId, Pageable pageable) {
-        return groupMemberRepository.findAllByActivityGroupId(activityGroupId, pageable);
-    }
-
     public List<GroupMember> getGroupMemberByActivityGroupIdAndStatus(Long activityGroupId, GroupMemberStatus status) {
         return groupMemberRepository.findAllByActivityGroupIdAndStatus(activityGroupId, status);
     }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/application/ActivityGroupMemberService.java
@@ -59,7 +59,6 @@ public class ActivityGroupMemberService {
     private final ActivityGroupDetailsRepository activityGroupDetailsRepository;
     private final ExternalRetrieveMemberUseCase externalRetrieveMemberUseCase;
     private final ExternalSendNotificationUseCase externalSendNotificationUseCase;
-    private final PaginationUtils paginationUtils;
 
     @Transactional(readOnly = true)
     public ActivityGroupDetailResponseDto getActivityGroup(Long activityGroupId) {
@@ -100,7 +99,7 @@ public class ActivityGroupMemberService {
                 .map(this::getActivityGroupStatusResponseDto)
                 .toList();
 
-        List<ActivityGroupStatusResponseDto> paginatedActivityGroupDtos = paginationUtils.applySortingAndSlicing(activityGroupDtos, pageable);
+        List<ActivityGroupStatusResponseDto> paginatedActivityGroupDtos = PaginationUtils.applySortingAndSlicing(activityGroupDtos, pageable);
 
         return new PagedResponseDto<>(paginatedActivityGroupDtos, activityGroups.size(), pageable);
     }
@@ -174,7 +173,7 @@ public class ActivityGroupMemberService {
                 .map(this::getActivityGroupStatusResponseDto)
                 .toList();
 
-        List<ActivityGroupStatusResponseDto> paginatedActivityGroups = paginationUtils.applySortingAndSlicing(activityGroups, pageable);
+        List<ActivityGroupStatusResponseDto> paginatedActivityGroups = PaginationUtils.applySortingAndSlicing(activityGroups, pageable);
 
         return new PagedResponseDto<>(paginatedActivityGroups, activityGroups.size(), pageable);
     }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepository.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepository.java
@@ -1,7 +1,6 @@
 package page.clab.api.domain.activity.activitygroup.dao;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
@@ -28,8 +27,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, GroupM
     Optional<GroupMember> findByActivityGroupAndMemberId(ActivityGroup activityGroup, String memberId);
 
     List<GroupMember> findAllByActivityGroupIdOrderByMemberIdAsc(Long activityGroupId);
-
-    Page<GroupMember> findAllByActivityGroupId(Long activityGroupId, Pageable pageable);
 
     Page<GroupMember> findAllByActivityGroupIdAndStatus(Long activityGroupId, GroupMemberStatus status, org.springframework.data.domain.Pageable pageable);
 

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepositoryCustom.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepositoryCustom.java
@@ -1,5 +1,7 @@
 package page.clab.api.domain.activity.activitygroup.dao;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import page.clab.api.domain.activity.activitygroup.domain.GroupMember;
 
 import java.util.List;
@@ -9,4 +11,6 @@ public interface GroupMemberRepositoryCustom {
     long countAcceptedMembersByActivityGroupId(Long activityGroupId);
 
     List<GroupMember> findLeaderByActivityGroupId(Long activityGroupId);
+
+    Page<GroupMember> findAllByActivityGroupId(Long activityGroupId, Pageable pageable);
 }

--- a/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepositoryImpl.java
+++ b/src/main/java/page/clab/api/domain/activity/activitygroup/dao/GroupMemberRepositoryImpl.java
@@ -1,15 +1,21 @@
 package page.clab.api.domain.activity.activitygroup.dao;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-import page.clab.api.domain.activity.activitygroup.domain.ActivityGroupRole;
-import page.clab.api.domain.activity.activitygroup.domain.GroupMember;
-import page.clab.api.domain.activity.activitygroup.domain.GroupMemberStatus;
-import page.clab.api.domain.activity.activitygroup.domain.QGroupMember;
+import page.clab.api.domain.activity.activitygroup.domain.*;
+import page.clab.api.global.util.OrderSpecifierUtil;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 @Repository
 @RequiredArgsConstructor
@@ -41,5 +47,50 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
         return queryFactory.selectFrom(qGroupMember)
                 .where(builder)
                 .fetch();
+    }
+
+    @Override
+    public Page<GroupMember> findAllByActivityGroupId(Long activityGroupId, Pageable pageable) {
+        QGroupMember qGroupMember = QGroupMember.groupMember;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (activityGroupId != null) builder.and(qGroupMember.activityGroup.id.eq(activityGroupId));
+
+        OrderSpecifier<Integer> leaderOrder = new CaseBuilder()
+                .when(qGroupMember.role.eq(ActivityGroupRole.LEADER)).then(0)
+                .otherwise(1)
+                .asc();
+
+        OrderSpecifier<Integer> statusOrder = pageable.getSort().stream()
+                .filter(order -> order.getProperty().equals("status"))
+                .findFirst()
+                .map(order -> new CaseBuilder()
+                        .when(qGroupMember.status.eq(GroupMemberStatus.WAITING)).then(0)
+                        .when(qGroupMember.status.eq(GroupMemberStatus.ACCEPTED)).then(1)
+                        .when(qGroupMember.status.eq(GroupMemberStatus.REJECTED)).then(2)
+                        .otherwise(3)
+                        .asc())
+                .orElse(null);
+
+        OrderSpecifier<?>[] dynamicOrderSpecifiers = OrderSpecifierUtil.getOrderSpecifiers(pageable, qGroupMember);
+
+        List<GroupMember> groupMembers = queryFactory.selectFrom(qGroupMember)
+                .where(builder)
+                .orderBy(Stream.concat(
+                        Stream.of(leaderOrder, statusOrder).filter(Objects::nonNull),
+                        Arrays.stream(dynamicOrderSpecifiers)
+                ).toArray(OrderSpecifier[]::new))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory.select(qGroupMember.count())
+                .from(qGroupMember)
+                .where(builder)
+                .fetchOne();
+
+        long totalElements = total != null ? total : 0;
+
+        return new PageImpl<>(groupMembers, pageable, totalElements);
     }
 }

--- a/src/main/java/page/clab/api/global/common/dto/PagedResponseDto.java
+++ b/src/main/java/page/clab/api/global/common/dto/PagedResponseDto.java
@@ -92,7 +92,10 @@ public class PagedResponseDto<T> {
      * @param ts 콘텐츠 아이템 리스트
      * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
      * @param size 전체 아이템 수
+     *
+     * @deprecated 슬라이싱과 정렬을 담당하는 새로운 Util 클래스의 도입으로 사라질 메서드입니다.
      */
+    @Deprecated
     public PagedResponseDto(List<T> ts, Pageable pageable, int size) {
         this.currentPage = pageable.getPageNumber();
         this.hasPrevious = pageable.getPageNumber() > 0;
@@ -105,9 +108,9 @@ public class PagedResponseDto<T> {
 
     /**
      * List와 Pageable 객체를 사용하여 PagedResponseDto를 생성하는 생성자입니다.
-     * 페이지네이션과 정렬이 적용됩니다.
      *
      * @param ts 콘텐츠 아이템 리스트
+     * @param totalItems 전체 아이템 수
      * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
      */
     public PagedResponseDto(List<T> ts, int totalItems, Pageable pageable) {
@@ -117,25 +120,7 @@ public class PagedResponseDto<T> {
         this.totalPages = (totalItems != 0) ? (int) Math.ceil((double) totalItems / pageable.getPageSize()) : 0;
         this.totalItems = totalItems;
         this.take = ts.size();
-        this.items = applySortingIfNecessary(ts, pageable.getSort());
-    }
-
-    /**
-     * List와 Pageable 객체를 사용하여 PagedResponseDto를 생성하는 생성자입니다.
-     * 페이지네이션과 정렬이 적용됩니다.
-     * 전체 아이템 정렬 후, 슬라이싱이 적용됩니다.
-     *
-     * @param ts 콘텐츠 아이템 리스트
-     * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
-     */
-    public PagedResponseDto(List<T> ts, Pageable pageable) {
-        this.currentPage = pageable.getPageNumber();
-        this.hasPrevious = pageable.getPageNumber() > 0;
-        this.hasNext = pageable.getOffset() + pageable.getPageSize() < ts.size();
-        this.totalPages = (!ts.isEmpty()) ? (int) Math.ceil((double) ts.size() / pageable.getPageSize()) : 0;
-        this.totalItems = ts.size();
-        this.take = slicePageFromList(ts, pageable).size();
-        this.items = applySortingAndSlicing(ts, pageable);
+        this.items = ts;
     }
 
     /**
@@ -144,7 +129,10 @@ public class PagedResponseDto<T> {
      * @param items 정렬되지 않은 아이템 리스트
      * @param sort 정렬 기준을 포함한 Sort 객체
      * @return 정렬된 아이템 리스트
+     *
+     * @deprecated 슬라이싱과 정렬을 담당하는 새로운 Util 클래스의 도입으로 사라질 메서드입니다.
      */
+    @Deprecated
     private List<T> applySortingIfNecessary(List<T> items, Sort sort) {
         if (sort.isSorted()) {
             return sortItems(items, sort);
@@ -153,24 +141,15 @@ public class PagedResponseDto<T> {
     }
 
     /**
-     * 아이템 리스트에 정렬과 슬라이싱을 적용하는 메서드입니다.
-     *
-     * @param items 정렬되지 않은 아이템 리스트
-     * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
-     * @return 정렬 및 슬라이싱된 아이템 리스트
-     */
-    private List<T> applySortingAndSlicing(List<T> items, Pageable pageable) {
-        items = sortItems(items, pageable.getSort());
-        return slicePageFromList(items, pageable);
-    }
-
-    /**
      * Sort 객체를 사용하여 아이템 리스트를 정렬하는 메서드입니다.
      *
      * @param items 정렬되지 않은 아이템 리스트
      * @param sort 정렬 기준을 포함한 Sort 객체
      * @return 정렬된 아이템 리스트
+     *
+     * @deprecated 슬라이싱과 정렬을 담당하는 새로운 Util 클래스의 도입으로 사라질 메서드입니다.
      */
+    @Deprecated
     private List<T> sortItems(List<T> items, Sort sort) {
         Comparator<T> comparator = sort.stream()
                 .map(order -> {
@@ -194,26 +173,15 @@ public class PagedResponseDto<T> {
     }
 
     /**
-     * 주어진 아이템 리스트에 슬라이싱을 적용하여 해당 페이지의 아이템을 반환하는 메서드입니다.
-     *
-     * @param items 슬라이싱이 적용되지 않은 전체 아이템 리스트
-     * @param pageable 페이지네이션 정보와 페이지 크기를 포함한 Pageable 객체
-     * @return 해당 페이지에 속하는 아이템 리스트
-     */
-    private List<T> slicePageFromList(List<T> items, Pageable pageable) {
-        return items.stream()
-                .skip(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .toList();
-    }
-
-    /**
      * 리플렉션을 사용하여 객체의 특정 필드 값을 추출하는 메서드입니다.
      *
      * @param item 값을 추출할 객체
      * @param fieldName 추출할 필드 이름
      * @return 추출된 필드 값
+     *
+     * @deprecated 슬라이싱과 정렬을 담당하는 새로운 Util 클래스의 도입으로 사라질 메서드입니다.
      */
+    @Deprecated
     private Object extractFieldValue(T item, String fieldName) throws InvalidColumnException {
         try {
             var field = item.getClass().getDeclaredField(fieldName);

--- a/src/main/java/page/clab/api/global/common/dto/PagedResponseDto.java
+++ b/src/main/java/page/clab/api/global/common/dto/PagedResponseDto.java
@@ -110,6 +110,24 @@ public class PagedResponseDto<T> {
      * @param ts 콘텐츠 아이템 리스트
      * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
      */
+    public PagedResponseDto(List<T> ts, int totalItems, Pageable pageable) {
+        this.currentPage = pageable.getPageNumber();
+        this.hasPrevious = pageable.getPageNumber() > 0;
+        this.hasNext = pageable.getOffset() + pageable.getPageSize() < totalItems;
+        this.totalPages = (totalItems != 0) ? (int) Math.ceil((double) totalItems / pageable.getPageSize()) : 0;
+        this.totalItems = totalItems;
+        this.take = ts.size();
+        this.items = applySortingIfNecessary(ts, pageable.getSort());
+    }
+
+    /**
+     * List와 Pageable 객체를 사용하여 PagedResponseDto를 생성하는 생성자입니다.
+     * 페이지네이션과 정렬이 적용됩니다.
+     * 전체 아이템 정렬 후, 슬라이싱이 적용됩니다.
+     *
+     * @param ts 콘텐츠 아이템 리스트
+     * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
+     */
     public PagedResponseDto(List<T> ts, Pageable pageable) {
         this.currentPage = pageable.getPageNumber();
         this.hasPrevious = pageable.getPageNumber() > 0;
@@ -117,26 +135,7 @@ public class PagedResponseDto<T> {
         this.totalPages = (!ts.isEmpty()) ? (int) Math.ceil((double) ts.size() / pageable.getPageSize()) : 0;
         this.totalItems = ts.size();
         this.take = slicePageFromList(ts, pageable).size();
-        this.items = applySortingAndSlicingIfNecessary(ts, pageable, false);
-    }
-
-    /**
-     * List와 Pageable 객체를 사용하여 PagedResponseDto를 생성하는 생성자입니다.
-     * ActivityGroup 도메인에서 GroupMember 정렬 시 활용 가능합니다.
-     * 페이지네이션과 정렬이 적용됩니다.
-     *
-     * @param ts 콘텐츠 아이템 리스트
-     * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
-     * @param leaderUp 리더를 우선 배치할지 여부를 나타내는 플래그 (true일 경우 리더 우선 정렬 적용)
-     */
-    public PagedResponseDto(List<T> ts, Pageable pageable, boolean leaderUp) {
-        this.currentPage = pageable.getPageNumber();
-        this.hasPrevious = pageable.getPageNumber() > 0;
-        this.hasNext = pageable.getOffset() + pageable.getPageSize() < ts.size();
-        this.totalPages = (!ts.isEmpty()) ? (int) Math.ceil((double) ts.size() / pageable.getPageSize()) : 0;
-        this.totalItems = ts.size();
-        this.take = slicePageFromList(ts, pageable).size();
-        this.items = applySortingAndSlicingIfNecessary(ts, pageable, leaderUp);
+        this.items = applySortingAndSlicing(ts, pageable);
     }
 
     /**
@@ -154,19 +153,14 @@ public class PagedResponseDto<T> {
     }
 
     /**
-     * 정렬 및 페이지네이션(슬라이싱)을 적용하는 메서드입니다.
-     * 주어진 아이템 리스트에 대해 필요한 경우 정렬을 먼저 적용하고, 그 후 페이지네이션을 적용하여 슬라이스된 리스트를 반환합니다.
+     * 아이템 리스트에 정렬과 슬라이싱을 적용하는 메서드입니다.
      *
-     * @param items 정렬 및 페이지네이션이 적용되지 않은 아이템 리스트
-     * @param pageable 페이지네이션 정보와 정렬 기준을 포함한 Pageable 객체
-     * @param leaderUp 리더를 우선 배치할지 여부를 나타내는 플래그 (true일 경우 리더 우선 정렬 적용)
-     * @return 정렬 및 페이지네이션이 적용된 아이템 리스트
+     * @param items 정렬되지 않은 아이템 리스트
+     * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
+     * @return 정렬 및 슬라이싱된 아이템 리스트
      */
-    private List<T> applySortingAndSlicingIfNecessary(List<T> items, Pageable pageable, boolean leaderUp) {
-        Sort sort = pageable.getSort();
-        if (sort.isSorted()) {
-            items = leaderUp ? sortItemsLeaderUp(items, sort) : sortItems(items, sort);
-        }
+    private List<T> applySortingAndSlicing(List<T> items, Pageable pageable) {
+        items = sortItems(items, pageable.getSort());
         return slicePageFromList(items, pageable);
     }
 
@@ -196,46 +190,6 @@ public class PagedResponseDto<T> {
 
         return items.stream()
                 .sorted(comparator)
-                .toList();
-    }
-
-    /**
-     * Sort 객체를 사용하여 아이템 리스트를 정렬하는 메서드입니다.
-     * ActivityGroup의 Leader가 최상단에 위치하도록 정렬됩니다.
-     *
-     * @param items 정렬되지 않은 아이템 리스트
-     * @param sort 정렬 기준을 포함한 Sort 객체
-     * @return 정렬된 아이템 리스트
-     */
-    private List<T> sortItemsLeaderUp(List<T> items, Sort sort) {
-        Comparator<T> leaderComparator = Comparator.comparing(item -> {
-            try {
-                return "LEADER".equals(extractFieldValue(item, "role")) ? 0 : 1;
-            } catch (InvalidColumnException e) {
-                throw new RuntimeException(e);
-            }
-        });
-
-        Comparator<T> comparator = sort.stream()
-                .map(order -> {
-                    Comparator<T> itemComparator = Comparator.comparing(
-                            item -> {
-                                try {
-                                    return (Comparable) extractFieldValue(item, order.getProperty());
-                                } catch (InvalidColumnException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }
-                    );
-                    return order.isAscending() ? itemComparator : itemComparator.reversed();
-                })
-                .reduce(Comparator::thenComparing)
-                .orElseThrow(IllegalArgumentException::new);
-
-        Comparator<T> finalComparator = leaderComparator.thenComparing(comparator);
-
-        return items.stream()
-                .sorted(finalComparator)
                 .toList();
     }
 

--- a/src/main/java/page/clab/api/global/util/PaginationUtils.java
+++ b/src/main/java/page/clab/api/global/util/PaginationUtils.java
@@ -1,0 +1,85 @@
+package page.clab.api.global.util;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import page.clab.api.global.exception.InvalidColumnException;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Component
+public class PaginationUtils {
+
+    /**
+     * 아이템 리스트에 정렬을 적용하는 메서드입니다.
+     *
+     * @param items 정렬되지 않은 아이템 리스트
+     * @param sort 정렬 기준을 포함한 Sort 객체
+     * @return 정렬된 아이템 리스트
+     */
+    public <T> List<T> applySorting(List<T> items, Sort sort) {
+        Comparator<T> comparator = sort.stream()
+                .map(order -> {
+                    Comparator<T> itemComparator = Comparator.comparing(
+                            item -> {
+                                try {
+                                    return (Comparable) extractFieldValue(item, order.getProperty());
+                                } catch (InvalidColumnException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }
+                    );
+                    return order.isAscending() ? itemComparator : itemComparator.reversed();
+                })
+                .reduce(Comparator::thenComparing)
+                .orElseThrow(IllegalArgumentException::new);
+
+        return items.stream()
+                .sorted(comparator)
+                .toList();
+    }
+
+    /**
+     * 아이템 리스트에 슬라이싱을 적용하는 메서드입니다.
+     *
+     * @param items 슬라이싱되지 않은 아이템 리스트
+     * @param pageable 페이지네이션 정보를 포함하는 Pageable 객체
+     * @return 슬라이싱된 아이템 리스트
+     */
+    public <T> List<T> applySlicing(List<T> items, Pageable pageable) {
+        return items.stream()
+                .skip(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .toList();
+    }
+
+    /**
+     * 아이템 리스트에 정렬과 슬라이싱을 적용하는 메서드입니다.
+     *
+     * @param items 정렬 및 슬라이싱 되지 않은 아이템 리스트
+     * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
+     * @return 정렬 및 슬라이싱된 아이템 리스트
+     */
+    public <T> List<T> applySortingAndSlicing(List<T> items, Pageable pageable) {
+        List<T> sortedItems = applySorting(items, pageable.getSort());
+        return applySlicing(sortedItems, pageable);
+    }
+
+    /**
+     * 리플렉션을 사용하여 객체의 특정 필드 값을 추출하는 메서드입니다.
+     *
+     * @param item 값을 추출할 객체
+     * @param fieldName 추출할 필드 이름
+     * @return 추출된 필드 값
+     */
+    private <T> Object extractFieldValue(T item, String fieldName) throws InvalidColumnException {
+        try {
+            var field = item.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(item);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new InvalidColumnException("잘못된 필드 이름: " + fieldName);
+        }
+    }
+}

--- a/src/main/java/page/clab/api/global/util/PaginationUtils.java
+++ b/src/main/java/page/clab/api/global/util/PaginationUtils.java
@@ -18,7 +18,7 @@ public class PaginationUtils {
      * @param sort 정렬 기준을 포함한 Sort 객체
      * @return 정렬된 아이템 리스트
      */
-    public <T> List<T> applySorting(List<T> items, Sort sort) {
+    public static <T> List<T> applySorting(List<T> items, Sort sort) {
         if (!sort.isSorted()) {
             return items;
         }
@@ -51,7 +51,7 @@ public class PaginationUtils {
      * @param pageable 페이지네이션 정보를 포함하는 Pageable 객체
      * @return 슬라이싱된 아이템 리스트
      */
-    public <T> List<T> applySlicing(List<T> items, Pageable pageable) {
+    public static <T> List<T> applySlicing(List<T> items, Pageable pageable) {
         return items.stream()
                 .skip(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -65,7 +65,7 @@ public class PaginationUtils {
      * @param pageable 페이지네이션 정보와 정렬 기준을 포함하는 Pageable 객체
      * @return 정렬 및 슬라이싱된 아이템 리스트
      */
-    public <T> List<T> applySortingAndSlicing(List<T> items, Pageable pageable) {
+    public static <T> List<T> applySortingAndSlicing(List<T> items, Pageable pageable) {
         List<T> sortedItems = applySorting(items, pageable.getSort());
         return applySlicing(sortedItems, pageable);
     }
@@ -77,7 +77,7 @@ public class PaginationUtils {
      * @param fieldName 추출할 필드 이름
      * @return 추출된 필드 값
      */
-    private <T> Object extractFieldValue(T item, String fieldName) throws InvalidColumnException {
+    private static <T> Object extractFieldValue(T item, String fieldName) throws InvalidColumnException {
         try {
             var field = item.getClass().getDeclaredField(fieldName);
             field.setAccessible(true);

--- a/src/main/java/page/clab/api/global/util/PaginationUtils.java
+++ b/src/main/java/page/clab/api/global/util/PaginationUtils.java
@@ -19,6 +19,10 @@ public class PaginationUtils {
      * @return 정렬된 아이템 리스트
      */
     public <T> List<T> applySorting(List<T> items, Sort sort) {
+        if (!sort.isSorted()) {
+            return items;
+        }
+
         Comparator<T> comparator = sort.stream()
                 .map(order -> {
                     Comparator<T> itemComparator = Comparator.comparing(


### PR DESCRIPTION
## Summary

> #577 

`활동 멤버 및 지원서 조회` api에서, 페이지에서만 정렬되도록 하는 것이 아닌, 전체 데이터를 대상으로 정렬을 한 후 페이지가 나눠지도록 변경했습니다.
또한, 정렬 시 리더가 최상단에 위치할 수 있도록 `PagedResponseDto`에 새로운 생성자를 만들고, 그에 따른 변경점을 수정했습니다.

작업 도중, `내가 지원한 활동 목록 조회`, `나의 활동 목록 조회`에서도 같은 문제를 발견해 수정했습니다.
해당 변경들은 프론트엔드 및 운영진분과 함께 의논하여 문제를 발견하고, 수정했습니다.

## Tasks

- 전체 데이터를 대상으로 정렬하도록 변경
- 리더가 최상단에 위치할 수 있도록 변경

## Results

```
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 4,
    "take": 4,
    "items": [
      {
        "memberId": "leader",
        "memberName": "리더",
        "role": "LEADER",
        "status": "ACCEPTED",
        "applyReason": ""
      },
      {
        "memberId": "202500001",
        "memberName": "설윤",
        "role": "NONE",
        "status": "WAITING",
        "applyReason": "백엔드에 관심이 있어서"
      },
      {
        "memberId": "202500003",
        "memberName": "김민지",
        "role": "MEMBER",
        "status": "ACCEPTED",
        "applyReason": "백엔드에 관심이 있어서"
      },
      {
        "memberId": "202500002",
        "memberName": "오해원",
        "role": "NONE",
        "status": "REJECTED",
        "applyReason": "백엔드에 관심이 있어서"
      }
    ]
  }
}
```
