### PR TITLE
refactor: 이메일 템플릿 하드코딩 개선 및 외부 관리로 전환 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/memberManagement/member/application/event/ApplicationMemberCreatedProcessor.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/application/event/ApplicationMemberCreatedProcessor.java
@@ -35,7 +35,7 @@ public class ApplicationMemberCreatedProcessor implements ApplicationEventProces
         String finalPassword = manageMemberPasswordUseCase.generateOrRetrievePassword(member.getPassword());
         member.updatePassword(finalPassword, passwordEncoder);
         registerMemberPort.save(member);
-        emailService.broadcastEmailToApprovedMember(member, finalPassword);
+        emailService.sendAccountCreationEmail(member, finalPassword);
     }
 
     @Override

--- a/src/main/java/page/clab/api/domain/memberManagement/member/application/service/MemberPasswordManagementService.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/application/service/MemberPasswordManagementService.java
@@ -45,7 +45,7 @@ public class MemberPasswordManagementService implements ManageMemberPasswordUseC
         Member member = validateResetPasswordRequest(requestDto);
         String code = verificationService.generateVerificationCode();
         verificationService.saveVerificationCode(member.getId(), code);
-        emailService.sendPasswordResetEmail(member, code);
+        emailService.sendPasswordResetCodeEmail(member, code);
         return member.getId();
     }
 

--- a/src/main/java/page/clab/api/domain/memberManagement/member/application/service/MemberPasswordManagementService.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/application/service/MemberPasswordManagementService.java
@@ -35,7 +35,7 @@ public class MemberPasswordManagementService implements ManageMemberPasswordUseC
         member.updatePassword(newPassword, passwordEncoder);
         registerMemberPort.save(member);
 
-        emailService.broadcastEmailToApprovedMember(member, newPassword);
+        emailService.sendAccountCreationEmail(member, newPassword);
         return member.getId();
     }
 

--- a/src/main/java/page/clab/api/domain/memberManagement/member/application/service/MemberPasswordManagementService.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/application/service/MemberPasswordManagementService.java
@@ -35,7 +35,7 @@ public class MemberPasswordManagementService implements ManageMemberPasswordUseC
         member.updatePassword(newPassword, passwordEncoder);
         registerMemberPort.save(member);
 
-        emailService.sendAccountCreationEmail(member, newPassword);
+        emailService.sendNewPasswordEmail(member, newPassword);
         return member.getId();
     }
 

--- a/src/main/java/page/clab/api/domain/memberManagement/member/application/service/MemberRegisterService.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/application/service/MemberRegisterService.java
@@ -42,7 +42,7 @@ public class MemberRegisterService implements RegisterMemberUseCase {
         member.updatePassword(finalPassword, passwordEncoder);
         registerMemberPort.save(member);
         createPositionByMember(member);
-        emailService.broadcastEmailToApprovedMember(member, finalPassword);
+        emailService.sendAccountCreationEmail(member, finalPassword);
         return member.getId();
     }
 

--- a/src/main/java/page/clab/api/global/common/email/application/EmailAsyncService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailAsyncService.java
@@ -73,7 +73,9 @@ public class EmailAsyncService {
             messageHelper.setTo(task.getTo());
             messageHelper.setSubject(task.getSubject());
             messageHelper.setText(task.getContent(), true);
+
             setImageInTemplate(messageHelper, task.getTemplateType());
+
             if (task.getFiles() != null) {
                 for (File file : task.getFiles()) {
                     messageHelper.addAttachment(MimeUtility.encodeText(file.getName(), "UTF-8", "B"), file);
@@ -91,7 +93,7 @@ public class EmailAsyncService {
     }
 
     private void setImageInTemplate(MimeMessageHelper messageHelper, EmailTemplateType templateType) throws MessagingException {
-        if (Objects.requireNonNull(templateType) == EmailTemplateType.NORMAL) {
+        if (Objects.equals(templateType.getTemplateName(), "clabEmail.html")) {
             messageHelper.addInline("image-1", new ClassPathResource("images/image-1.png"));
         }
     }

--- a/src/main/java/page/clab/api/global/common/email/application/EmailService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailService.java
@@ -80,7 +80,7 @@ public class EmailService {
     }
 
     public void sendPasswordResetCodeEmail(Member member, String code) {
-        EmailTemplateProperties.Template template = emailTemplateProperties.getTemplate(EmailTemplateType.PASSWORD_RESET);
+        EmailTemplateProperties.Template template = emailTemplateProperties.getTemplate(EmailTemplateType.PASSWORD_RESET_CODE);
 
         String subject = template.getSubject();
         String content = template.getContent()
@@ -90,7 +90,7 @@ public class EmailService {
                 List.of(member.getEmail()),
                 subject,
                 content,
-                EmailTemplateType.PASSWORD_RESET
+                EmailTemplateType.PASSWORD_RESET_CODE
         );
 
         try {
@@ -98,6 +98,21 @@ public class EmailService {
             emailAsyncService.sendEmailAsync(member.getEmail(), emailDto.getSubject(), emailContent, null, emailDto.getEmailTemplateType());
         } catch (Exception e) {
             throw new MessageSendingFailedException(member.getEmail() + " 비밀번호 재발급 인증 메일 전송에 실패했습니다.");
+        }
+    }
+
+    public void sendNewPasswordEmail(Member member, String newPassword) {
+        EmailTemplateProperties.Template template = emailTemplateProperties.getTemplate(EmailTemplateType.NEW_PASSWORD);
+        String content = template.getContent()
+                .replace("{{id}}", member.getId())
+                .replace("{{password}}", newPassword);
+
+        EmailDto emailDto = EmailDto.create(List.of(member.getEmail()), template.getSubject(), content, EmailTemplateType.NEW_PASSWORD);
+        try {
+            String emailContent = generateEmailContent(emailDto, member.getName());
+            emailAsyncService.sendEmailAsync(member.getEmail(), emailDto.getSubject(), emailContent, null, emailDto.getEmailTemplateType());
+        } catch (MessagingException e) {
+            throw new MessageSendingFailedException(member.getEmail() + " 비밀번호 재설정 안내 메일 전송에 실패했습니다.");
         }
     }
 

--- a/src/main/java/page/clab/api/global/common/email/application/EmailService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailService.java
@@ -3,24 +3,15 @@ package page.clab.api.global.common.email.application;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FilenameUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 import page.clab.api.domain.memberManagement.member.domain.Member;
-import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 import page.clab.api.global.common.email.domain.EmailTemplateType;
 import page.clab.api.global.common.email.dto.request.EmailDto;
 import page.clab.api.global.common.email.exception.MessageSendingFailedException;
 import page.clab.api.global.config.EmailTemplateProperties;
-import page.clab.api.global.util.FileUtil;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -28,33 +19,9 @@ import java.util.List;
 @Slf4j
 public class EmailService {
 
-    private final ExternalRetrieveMemberUseCase externalRetrieveMemberUseCase;
-    private final SpringTemplateEngine springTemplateEngine;
     private final EmailAsyncService emailAsyncService;
     private final EmailTemplateProperties emailTemplateProperties;
-
-    @Value("${resource.file.path}")
-    private String filePath;
-
-    public List<String> broadcastEmail(EmailDto emailDto, List<MultipartFile> multipartFiles) {
-        List<File> convertedFiles = multipartFiles != null && !multipartFiles.isEmpty()
-                ? convertMultipartFiles(multipartFiles)
-                : new ArrayList<>();
-
-        List<String> successfulAddresses = Collections.synchronizedList(new ArrayList<>());
-
-        emailDto.getTo().parallelStream().forEach(address -> {
-            try {
-                Member recipient = externalRetrieveMemberUseCase.findByEmail(address);
-                String emailContent = generateEmailContent(emailDto, recipient.getName());
-                emailAsyncService.sendEmailAsync(address, emailDto.getSubject(), emailContent, convertedFiles, emailDto.getEmailTemplateType());
-                successfulAddresses.add(address);
-            } catch (MessagingException e) {
-                throw new MessageSendingFailedException(address + "에게 이메일을 보내는데 실패했습니다.");
-            }
-        });
-        return successfulAddresses;
-    }
+    private final SpringTemplateEngine springTemplateEngine;
 
     public void sendAccountCreationEmail(Member member, String password) {
         EmailTemplateProperties.Template template = emailTemplateProperties.getTemplate(EmailTemplateType.ACCOUNT_CREATION);
@@ -103,42 +70,25 @@ public class EmailService {
 
     public void sendNewPasswordEmail(Member member, String newPassword) {
         EmailTemplateProperties.Template template = emailTemplateProperties.getTemplate(EmailTemplateType.NEW_PASSWORD);
+
+        String subject = template.getSubject();
         String content = template.getContent()
                 .replace("{{id}}", member.getId())
                 .replace("{{password}}", newPassword);
 
-        EmailDto emailDto = EmailDto.create(List.of(member.getEmail()), template.getSubject(), content, EmailTemplateType.NEW_PASSWORD);
+        EmailDto emailDto = EmailDto.create(
+                List.of(member.getEmail()),
+                subject,
+                content,
+                EmailTemplateType.NEW_PASSWORD
+        );
+
         try {
             String emailContent = generateEmailContent(emailDto, member.getName());
             emailAsyncService.sendEmailAsync(member.getEmail(), emailDto.getSubject(), emailContent, null, emailDto.getEmailTemplateType());
         } catch (MessagingException e) {
             throw new MessageSendingFailedException(member.getEmail() + " 비밀번호 재설정 안내 메일 전송에 실패했습니다.");
         }
-    }
-
-    private List<File> convertMultipartFiles(List<MultipartFile> multipartFiles) {
-        List<File> convertedFiles = new ArrayList<>();
-        for (MultipartFile multipartFile : multipartFiles) {
-            File file = convertMultipartFileToFile(multipartFile);
-            convertedFiles.add(file);
-        }
-        return convertedFiles;
-    }
-
-    private File convertMultipartFileToFile(MultipartFile multipartFile) {
-        String originalFilename = multipartFile.getOriginalFilename();
-        String extension = FilenameUtils.getExtension(originalFilename);
-        String path = filePath + File.separator + "temp" + File.separator + FileUtil.makeFileName(extension);
-        path = path.replace("/", File.separator).replace("\\", File.separator);
-        File file = new File(path);
-        FileUtil.ensureParentDirectoryExists(file, filePath);
-
-        try {
-            multipartFile.transferTo(file);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to convert MultipartFile to File", e);
-        }
-        return file;
     }
 
     private String generateEmailContent(EmailDto emailDto, String name) {

--- a/src/main/java/page/clab/api/global/common/email/application/EmailService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailService.java
@@ -56,7 +56,7 @@ public class EmailService {
         return successfulAddresses;
     }
 
-    public void broadcastEmailToApprovedMember(Member member, String password) {
+    public void sendAccountCreationEmail(Member member, String password) {
         EmailTemplateProperties.Template template = emailTemplateProperties.getTemplate(EmailTemplateType.ACCOUNT_CREATION);
 
         String subject = template.getSubject();

--- a/src/main/java/page/clab/api/global/common/email/application/EmailService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailService.java
@@ -38,12 +38,7 @@ public class EmailService {
                 EmailTemplateType.ACCOUNT_CREATION
         );
 
-        try {
-            String emailContent = generateEmailContent(emailDto, member.getName());
-            emailAsyncService.sendEmailAsync(member.getEmail(), emailDto.getSubject(), emailContent, null, emailDto.getEmailTemplateType());
-        } catch (MessagingException e) {
-            throw new MessageSendingFailedException(member.getEmail() + " 계정 발급 안내 메일 전송에 실패했습니다.");
-        }
+        sendEmail(emailDto, member, " 계정 발급 안내 메일 전송에 실패했습니다.");
     }
 
     public void sendPasswordResetCodeEmail(Member member, String code) {
@@ -60,12 +55,7 @@ public class EmailService {
                 EmailTemplateType.PASSWORD_RESET_CODE
         );
 
-        try {
-            String emailContent = generateEmailContent(emailDto, member.getName());
-            emailAsyncService.sendEmailAsync(member.getEmail(), emailDto.getSubject(), emailContent, null, emailDto.getEmailTemplateType());
-        } catch (Exception e) {
-            throw new MessageSendingFailedException(member.getEmail() + " 비밀번호 재발급 인증 메일 전송에 실패했습니다.");
-        }
+        sendEmail(emailDto, member, " 비밀번호 재발급 인증 메일 전송에 실패했습니다.");
     }
 
     public void sendNewPasswordEmail(Member member, String newPassword) {
@@ -83,11 +73,15 @@ public class EmailService {
                 EmailTemplateType.NEW_PASSWORD
         );
 
+        sendEmail(emailDto, member, " 비밀번호 재설정 안내 메일 전송에 실패했습니다.");
+    }
+
+    private void sendEmail(EmailDto emailDto, Member member, String message) {
         try {
             String emailContent = generateEmailContent(emailDto, member.getName());
             emailAsyncService.sendEmailAsync(member.getEmail(), emailDto.getSubject(), emailContent, null, emailDto.getEmailTemplateType());
         } catch (MessagingException e) {
-            throw new MessageSendingFailedException(member.getEmail() + " 비밀번호 재설정 안내 메일 전송에 실패했습니다.");
+            throw new MessageSendingFailedException(member.getEmail() + message);
         }
     }
 

--- a/src/main/java/page/clab/api/global/common/email/application/EmailService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailService.java
@@ -79,7 +79,7 @@ public class EmailService {
         }
     }
 
-    public void sendPasswordResetEmail(Member member, String code) {
+    public void sendPasswordResetCodeEmail(Member member, String code) {
         EmailTemplateProperties.Template template = emailTemplateProperties.getTemplate(EmailTemplateType.PASSWORD_RESET);
 
         String subject = template.getSubject();

--- a/src/main/java/page/clab/api/global/common/email/domain/EmailTemplateType.java
+++ b/src/main/java/page/clab/api/global/common/email/domain/EmailTemplateType.java
@@ -1,7 +1,5 @@
 package page.clab.api.global.common.email.domain;
 
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,9 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum EmailTemplateType {
 
-    NORMAL("NORMAL", "기본", "clabEmail.html");
+    ACCOUNT_CREATION("account-creation", "계정 생성 템플릿", "clabEmail.html"),
+    PASSWORD_RESET("password-reset", "비밀번호 재설정 템플릿", "clabEmail.html");
 
-    @Enumerated(EnumType.STRING)
     private final String key;
     private final String description;
     private final String templateName;

--- a/src/main/java/page/clab/api/global/common/email/domain/EmailTemplateType.java
+++ b/src/main/java/page/clab/api/global/common/email/domain/EmailTemplateType.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum EmailTemplateType {
 
-    ACCOUNT_CREATION("account-creation", "계정 생성 템플릿", "clabEmail.html"),
-    PASSWORD_RESET("password-reset", "비밀번호 재설정 템플릿", "clabEmail.html");
+    ACCOUNT_CREATION("account-creation", "계정 생성", "clabEmail.html"),
+    PASSWORD_RESET_CODE("password-reset-code", "비밀번호 재설정", "clabEmail.html"),
+    NEW_PASSWORD("new-password", "새 비밀번호", "clabEmail.html");
 
     private final String key;
     private final String description;

--- a/src/main/java/page/clab/api/global/common/email/dto/request/EmailDto.java
+++ b/src/main/java/page/clab/api/global/common/email/dto/request/EmailDto.java
@@ -27,7 +27,7 @@ public class EmailDto {
     private String content;
 
     @NotNull(message = "{notNull.email.templateType}")
-    @Schema(description = "이메일 템플릿", example = "NORMAL")
+    @Schema(description = "이메일 템플릿", example = "ACCOUNT_CREATION")
     private EmailTemplateType emailTemplateType;
 
     public static EmailDto create(List<String> to, String subject, String content, EmailTemplateType emailTemplateType) {

--- a/src/main/java/page/clab/api/global/config/EmailTemplateProperties.java
+++ b/src/main/java/page/clab/api/global/config/EmailTemplateProperties.java
@@ -1,0 +1,33 @@
+package page.clab.api.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import page.clab.api.global.common.email.domain.EmailTemplateType;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "email")
+public class EmailTemplateProperties {
+
+    private Map<String, Template> templates;
+
+    public Template getTemplate(EmailTemplateType templateType) {
+        Template template = templates.get(templateType.getKey());
+        if (template == null) {
+            throw new IllegalArgumentException("템플릿을 찾을 수 없습니다: " + templateType);
+        }
+        return template;
+    }
+
+    @Getter
+    @Setter
+    public static class Template {
+        private String subject;
+        private String content;
+    }
+}

--- a/src/main/resources/templates/clabEmail.html
+++ b/src/main/resources/templates/clabEmail.html
@@ -317,7 +317,7 @@
                     <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:'Montserrat',sans-serif;" align="center">
 
                       <div class="v-font-size" style="font-size: 14px; color: #908f8f; line-height: 200%; text-align: center; word-wrap: break-word;">
-                        <p style="line-height: 200%;">C-Lab  |  경기대학교 컴퓨터공학부 개발보안동아리</p>
+                        <p style="line-height: 200%;">C-Lab  |  경기대학교 AI컴퓨터공학부 개발동아리</p>
                       </div>
 
                     </td>


### PR DESCRIPTION
## Summary

> #559 

기존의 하드코딩된 이메일 내용을 YAML 파일로 이동하고, 비밀번호 재설정 관련 메일 전송 메소드를 개선했습니다. 이메일 템플릿 관리의 유연성을 높이고 코드에서 템플릿 변경 없이 YAML에서 쉽게 수정할 수 있도록 개선하였습니다.

## Tasks

- 이메일 전송 메소드에서 이메일 내용 하드코딩을 제거하고, YAML에서 이메일 템플릿을 불러오는 방식으로 수정
- YAML 파일에 `new-password` 템플릿을 추가
- `EmailService`의 템플릿 로직을 `EmailTemplateProperties`를 사용하여 동적으로 이메일 내용을 불러오도록 리팩토링
- 이메일 템플릿에 기재된 동아리 소속명 수정

## 추가된 YAML

```yaml
email:
  templates:
    account-creation:
      subject: "C-Lab 계정 발급 안내"
      content: |
        정식으로 C-Lab의 일원이 된 것을 축하드립니다.
        C-Lab과 함께하는 동안 불타는 열정으로 모든 원하는 목표를 이루어 내시기를 바라고,
        훗날, 당신의 합류가 C-Lab에겐 최고의 행운이었다고 기억되기를 희망합니다.

        로그인을 위해 아래의 계정 정보를 확인해주세요.
        ID: {{id}}
        Password: {{password}}
        로그인 후 비밀번호를 변경해주세요.
    password-reset-code:
      subject: "C-Lab 비밀번호 재발급 인증 안내"
      content: |
        C-Lab 비밀번호 재발급 인증 안내 메일입니다.
        인증번호는 {{code}}입니다.
        해당 인증번호를 비밀번호 재설정 페이지에 입력해주세요.
        재설정시 비밀번호는 인증번호로 대체됩니다.
    new-password:
      subject: "C-Lab 비밀번호 재설정 안내"
      content: |
        C-Lab 비밀번호 재설정 안내 메일입니다.
        아래의 새로운 비밀번호로 로그인해 주세요.
        ID: {{id}}
        Password: {{password}}
        로그인 후 비밀번호를 변경해 주세요.
```

## ETC
- 이메일 내용이 자주 변경되는 경우, 코드에서 템플릿을 직접 수정하지 않고 YAML 파일을 수정하여 쉽게 반영할 수 있도록 개선되었습니다.

## Screenshot
![image](https://github.com/user-attachments/assets/d783e415-4954-483c-9636-a97a11269c48)
![image](https://github.com/user-attachments/assets/51435512-9b16-426d-bc0a-f3a73b526b5c)
![image](https://github.com/user-attachments/assets/06920abe-e7c9-4881-990a-7d632d5f0438)
