### PR TITLE
refactor: 비정상적인 서버 접근 시 슬랙 알림 전송 로직 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/global/auth/filter/InvalidEndpointAccessFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/InvalidEndpointAccessFilter.java
@@ -55,12 +55,12 @@ public class InvalidEndpointAccessFilter extends GenericFilterBean {
         String message = "서버 내부 파일 및 디렉토리에 대한 접근이 감지되었습니다.";
 
         log.info("[{}:{}] {} {} {} {}", clientIpAddress, id, requestUrl, httpMethod, httpStatus, message);
-        slackService.sendSecurityAlertNotification(request, SecurityAlertType.ABNORMAL_ACCESS, message);
 
         if (!externalRetrieveBlacklistIpUseCase.existsByIpAddress(clientIpAddress)) {
             externalRegisterBlacklistIpUseCase.save(
                     BlacklistIp.create(clientIpAddress, "서버 내부 파일 및 디렉토리에 대한 접근 시도")
             );
+            slackService.sendSecurityAlertNotification(request, SecurityAlertType.ABNORMAL_ACCESS, message);
             slackService.sendSecurityAlertNotification(request, SecurityAlertType.BLACKLISTED_IP_ADDED, "Added IP: " + clientIpAddress);
         }
         ResponseUtil.sendErrorResponse(response, httpStatus);

--- a/src/main/java/page/clab/api/global/auth/filter/InvalidEndpointAccessFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/InvalidEndpointAccessFilter.java
@@ -16,9 +16,9 @@ import page.clab.api.external.auth.blacklistIp.application.port.ExternalRegister
 import page.clab.api.external.auth.blacklistIp.application.port.ExternalRetrieveBlacklistIpUseCase;
 import page.clab.api.global.common.slack.application.SlackService;
 import page.clab.api.global.common.slack.domain.SecurityAlertType;
-import page.clab.api.global.config.SuspiciousPatterns;
 import page.clab.api.global.util.HttpReqResUtil;
 import page.clab.api.global.util.ResponseUtil;
+import page.clab.api.global.util.SecurityPatternChecker;
 
 import java.io.IOException;
 
@@ -36,7 +36,7 @@ public class InvalidEndpointAccessFilter extends GenericFilterBean {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         String path = httpRequest.getRequestURI();
         boolean isUploadedFileAccess = path.startsWith(fileURL);
-        boolean isSuspicious = SuspiciousPatterns.getSuspiciousPatterns().stream().anyMatch(pattern -> pattern.matcher(path).matches());
+        boolean isSuspicious = SecurityPatternChecker.matchesSuspiciousPattern(path);
 
         if (!isUploadedFileAccess && isSuspicious) {
             logAndRespondToSuspiciousAccess(httpRequest, (HttpServletResponse) response);

--- a/src/main/java/page/clab/api/global/auth/filter/InvalidEndpointAccessFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/InvalidEndpointAccessFilter.java
@@ -39,30 +39,47 @@ public class InvalidEndpointAccessFilter extends GenericFilterBean {
         boolean isSuspicious = SecurityPatternChecker.matchesSuspiciousPattern(path);
 
         if (!isUploadedFileAccess && isSuspicious) {
-            logAndRespondToSuspiciousAccess(httpRequest, (HttpServletResponse) response);
+            handleSuspiciousAccess(httpRequest, (HttpServletResponse) response);
         } else {
             chain.doFilter(request, response);
         }
     }
 
-    private void logAndRespondToSuspiciousAccess(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    private void handleSuspiciousAccess(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
+        int statusCode = HttpServletResponse.SC_FORBIDDEN;
+
+        logSuspiciousAccess(request, clientIpAddress);
+        sendSecurityAlertIfNotBlacklisted(request, clientIpAddress);
+
+        ResponseUtil.sendErrorResponse(response, statusCode);
+    }
+
+    private void logSuspiciousAccess(HttpServletRequest request, String clientIpAddress) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String id = (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
-        String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
         String requestUrl = request.getRequestURI();
         String httpMethod = request.getMethod();
-        int httpStatus = HttpServletResponse.SC_FORBIDDEN;
+        int statusCode = HttpServletResponse.SC_FORBIDDEN;
         String message = "서버 내부 파일 및 디렉토리에 대한 접근이 감지되었습니다.";
 
-        log.info("[{}:{}] {} {} {} {}", clientIpAddress, id, requestUrl, httpMethod, httpStatus, message);
+        log.info("[{}:{}] {} {} {} {}", clientIpAddress, id, requestUrl, httpMethod, statusCode, message);
+    }
 
+    private void sendSecurityAlertIfNotBlacklisted(HttpServletRequest request, String clientIpAddress) {
         if (!externalRetrieveBlacklistIpUseCase.existsByIpAddress(clientIpAddress)) {
             externalRegisterBlacklistIpUseCase.save(
                     BlacklistIp.create(clientIpAddress, "서버 내부 파일 및 디렉토리에 대한 접근 시도")
             );
-            slackService.sendSecurityAlertNotification(request, SecurityAlertType.ABNORMAL_ACCESS, message);
-            slackService.sendSecurityAlertNotification(request, SecurityAlertType.BLACKLISTED_IP_ADDED, "Added IP: " + clientIpAddress);
+            sendSecurityAlerts(request, clientIpAddress);
         }
-        ResponseUtil.sendErrorResponse(response, httpStatus);
+    }
+
+    private void sendSecurityAlerts(HttpServletRequest request, String clientIpAddress) {
+        String abnormalAccessMessage = "서버 내부 파일 및 디렉토리에 대한 접근이 감지되었습니다.";
+        String blacklistAddedMessage = "Added IP: " + clientIpAddress;
+
+        slackService.sendSecurityAlertNotification(request, SecurityAlertType.ABNORMAL_ACCESS, abnormalAccessMessage);
+        slackService.sendSecurityAlertNotification(request, SecurityAlertType.BLACKLISTED_IP_ADDED, blacklistAddedMessage);
     }
 }

--- a/src/main/java/page/clab/api/global/util/ApiLogger.java
+++ b/src/main/java/page/clab/api/global/util/ApiLogger.java
@@ -20,9 +20,9 @@ public class ApiLogger {
         String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
 
         String httpMethod = request.getMethod();
-        int httpStatus = response.getStatus();
+        int statusCode = response.getStatus();
 
-        log.info("[{}:{}] {} {} {} {}", clientIpAddress, id, fullUrl, httpMethod, httpStatus, message);
+        log.info("[{}:{}] {} {} {} {}", clientIpAddress, id, fullUrl, httpMethod, statusCode, message);
     }
 
     public void logRequestDuration(HttpServletRequest request, HttpServletResponse response, Exception ex) {
@@ -35,16 +35,16 @@ public class ApiLogger {
         String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
 
         String httpMethod = request.getMethod();
-        int httpStatus = response.getStatus();
+        int statusCode = response.getStatus();
 
         long startTime = (Long) request.getAttribute("startTime");
         long endTime = System.currentTimeMillis();
         long duration = endTime - startTime;
 
         if (ex == null) {
-            log.info("[{}:{}] {} {} {} {}ms", clientIpAddress, id, fullUrl, httpMethod, httpStatus, duration);
+            log.info("[{}:{}] {} {} {} {}ms", clientIpAddress, id, fullUrl, httpMethod, statusCode, duration);
         } else {
-            log.error("[{}:{}] {} {} {} {}ms, Exception: {}", clientIpAddress, id, fullUrl, httpMethod, httpStatus, duration, ex.getMessage());
+            log.error("[{}:{}] {} {} {} {}ms, Exception: {}", clientIpAddress, id, fullUrl, httpMethod, statusCode, duration, ex.getMessage());
         }
     }
 }

--- a/src/main/java/page/clab/api/global/util/SecurityPatternChecker.java
+++ b/src/main/java/page/clab/api/global/util/SecurityPatternChecker.java
@@ -1,18 +1,20 @@
-package page.clab.api.global.config;
-
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.context.annotation.Configuration;
+package page.clab.api.global.util;
 
 import java.util.List;
 import java.util.regex.Pattern;
 
-@Setter
-@Getter
-@Configuration
-public class SuspiciousPatterns {
+/**
+ * SecurityPatternChecker 클래스는 보안과 관련된 의심스러운 URL 패턴을 관리하고 검사하는 역할을 합니다.
+ * 이 클래스는 시스템 파일, 데이터베이스 백업, 또는 민감한 설정 파일에 대한 무단 접근을 시도하는
+ * 의심스러운 URL 경로를 사전에 정의된 패턴과 비교하여 확인할 수 있는 유틸리티 메소드를 제공합니다.
+ */
+public class SecurityPatternChecker {
 
-    @Getter
+    /**
+     * 보안과 관련된 의심스러운 URL 경로를 나타내는 사전 정의된 패턴 목록입니다.
+     * 이 패턴들은 시스템 파일, 백업 파일, 설정 파일 및 일반적으로 사용되는 웹 쉘 스크립트(.php, .asp, .jsp 등)에
+     * 대한 경로를 포함합니다. 해당 경로로의 무단 접근을 감지하는 데 사용됩니다.
+     */
     private static final List<Pattern> suspiciousPatterns = List.of(
             // 일반적인 웹 쉘 및 백도어
             Pattern.compile(".*\\.php.*"),
@@ -84,4 +86,17 @@ public class SuspiciousPatterns {
             Pattern.compile(".*\\/api_keys.*"),
             Pattern.compile(".*\\/passwords.*")
     );
+
+    /**
+     * 주어진 경로(path)가 의심스러운 패턴과 일치하는지 확인하는 메소드입니다.
+     * 이 메소드는 사전에 정의된 패턴 목록을 기반으로 경로를 검사하고,
+     * 해당 경로가 의심스러운 패턴과 일치하면 true를 반환합니다.
+     *
+     * @param path 요청된 URL 경로
+     * @return 경로가 의심스러운 패턴과 일치하는지 여부 (일치하면 true, 일치하지 않으면 false)
+     */
+    public static boolean matchesSuspiciousPattern(String path) {
+        return suspiciousPatterns.stream()
+                .anyMatch(pattern -> pattern.matcher(path).matches());
+    }
 }


### PR DESCRIPTION
## Summary

> #582 

비정상적인 접근 패턴 탐지와 슬랙 알림 전송 관련 코드를 리팩토링하였습니다. 이번 리팩토링을 통해 불필요한 슬랙 알림을 줄이고, 최초 비정상적인 접근 시에만 알림이 전송되도록 변경하였습니다. 또한, 코드의 가독성과 유지보수성을 높였습니다.

## Tasks

- **슬랙 알림 전송 로직 변경**
    - 최초 비정상적인 접근 시에만 슬랙 알림을 전송하고, 이후 동일한 IP에 대해서는 슬랙 알림을 전송하지 않도록 변경하였습니다.

- **비정상적인 접근 패턴 탐지 코드 분리**
    - `SecurityPatternChecker` 클래스를 통해 의심스러운 경로 패턴 탐지를 담당하도록 코드 분리.

- **`InvalidEndpointAccessFilter` 리팩토링**
    - 중복된 슬랙 알림 전송 로직을 하나로 통합.
    - `handleSuspiciousAccess`, `logSuspiciousAccess` 등으로 메소드를 분리하여 단일 책임 원칙을 준수하도록 개선.
    - 코드 내 상수화 및 메소드 분리로 가독성 및 유지보수성 향상.

## ETC

- 이번 리팩토링을 통해 비정상적인 접근에 대한 알림이 불필요하게 중복되지 않으며, 보안 패턴 검사가 더욱 명확하게 처리됩니다.