### PR TITLE
fix: 외부 공개 프로파일(application.yml)의 이메일 템플릿 설정 누락 수정 완료

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,35 @@ spring:
             enable: true
             required: true
 
+email:
+  templates:
+    account-creation:
+      subject: "C-Lab Account Creation Notice"
+      content: |
+        Congratulations on becoming an official member of C-Lab!
+        During your time with C-Lab, we hope that you achieve all your desired goals with burning passion,
+        and in the future, we hope that your joining C-Lab will be remembered as one of our greatest fortunes.
+
+        Please review the account details below to log in:
+        ID: {{id}}
+        Password: {{password}}
+        Please change your password after logging in.
+    password-reset-code:
+      subject: "C-Lab Password Reset Verification Notice"
+      content: |
+        This is a C-Lab password reset verification email.
+        Your verification code is {{code}}.
+        Please enter this verification code on the password reset page.
+        After resetting, your new password will be replaced with the verification code.
+    new-password:
+      subject: "C-Lab Password Reset Notice"
+      content: |
+        This is a C-Lab password reset notice.
+        Please log in using the new password below:
+        ID: {{id}}
+        Password: {{password}}
+        Please change your password after logging in.
+
 security:
   # C-Lab Auth
   auth:


### PR DESCRIPTION
## Summary

> #587 

이메일 템플릿 관련 설정을 YAML 파일로 이동하는 작업에서, 외부 공개 프로파일 `application.yml`에 대한 수정이 누락되었습니다. 이로 인해 YAML 파일에서 이메일 템플릿을 로드하는 설정이 정상적으로 적용되지 않는 문제를 수정합니다.

## Tasks

- **외부 공개 프로파일(application.yml) 수정**
    - 이메일 템플릿 로드 경로가 제대로 설정되지 않은 부분을 수정하여, 이메일 전송 시 YAML 파일에서 템플릿을 정상적으로 로드할 수 있도록 설정을 추가.

## 추가된 YAML

```yaml
email:
  templates:
    account-creation:
      subject: "C-Lab Account Creation Notice"
      content: |
        Congratulations on becoming an official member of C-Lab!
        During your time with C-Lab, we hope that you achieve all your desired goals with burning passion,
        and in the future, we hope that your joining C-Lab will be remembered as one of our greatest fortunes.

        Please review the account details below to log in:
        ID: {{id}}
        Password: {{password}}
        Please change your password after logging in.
    password-reset-code:
      subject: "C-Lab Password Reset Verification Notice"
      content: |
        This is a C-Lab password reset verification email.
        Your verification code is {{code}}.
        Please enter this verification code on the password reset page.
        After resetting, your new password will be replaced with the verification code.
    new-password:
      subject: "C-Lab Password Reset Notice"
      content: |
        This is a C-Lab password reset notice.
        Please log in using the new password below:
        ID: {{id}}
        Password: {{password}}
        Please change your password after logging in.
```