### PR TITLE
refactor: POST 요청 응답 상태코드 변경 (200 → 201) 완료

### DIFF
--- a/src/main/java/page/clab/api/global/filter/PostResponseFilter.java
+++ b/src/main/java/page/clab/api/global/filter/PostResponseFilter.java
@@ -1,0 +1,38 @@
+package page.clab.api.global.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * {@code PostResponseFilter}는 특정 API 요청에 대해 POST 요청의 응답 상태 코드를 수정하는 서블릿 필터입니다.
+ *
+ * <p>이 필터는 모든 API URL 패턴("/api/*")에 대해 등록되며, Spring 컴포넌트로 작동합니다.
+ * 만약 POST 요청의 응답 상태 코드가 200(OK)일 경우, 이를 201(Created)로 변경하여 리소스 생성에 대한 명확한 상태 코드를 제공합니다.</p>
+ */
+@WebFilter("/api/*")
+@Component
+public class PostResponseFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        // POST 요청이고 상태 코드가 200인 경우 상태 코드를 201로 변경
+        if (HttpMethod.POST.name().equalsIgnoreCase(httpRequest.getMethod()) && httpResponse.getStatus() == HttpServletResponse.SC_OK) {
+            httpResponse.setStatus(HttpServletResponse.SC_CREATED);
+        }
+
+        chain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## Summary

> #592 

`POST` 요청의 응답 상태 코드를 변경하는 필터를 추가했습니다.
이 필터는 `/api/*` 경로에 대한 `POST` 요청의 응답 상태 코드가 200일 경우 이를 `201`로 수정합니다.

## Tasks

- `/api/*` 경로의 모든 `POST` 요청을 대상으로 `HttpServletResponse`의 상태 코드가 200일 경우 `201`로 변경하도록 하는 서블릿 필터 추가

## Log

**POST**
```bash
INFO  page.clab.api.global.util.ApiLogger - [0:0:0:0:0:0:0:1:test] /api/v1/recruitments POST 201 79ms
INFO  page.clab.api.global.util.ApiLogger - [0:0:0:0:0:0:0:1:test] /api/v1/books POST 201 27ms
INFO  page.clab.api.global.util.ApiLogger - [0:0:0:0:0:0:0:1:test] /api/v1/awards POST 201 34ms
INFO  page.clab.api.global.util.ApiLogger - [0:0:0:0:0:0:0:1:test] /api/v1/awards POST 201 4ms
```

**POST 외 메소드**
```bash
INFO  page.clab.api.global.util.ApiLogger - [0:0:0:0:0:0:0:1:test] /api/v1/awards?page=0&size=20&sortBy=awardDate&sortDirection=desc GET 200 110ms
INFO  page.clab.api.global.util.ApiLogger - [0:0:0:0:0:0:0:1:test] /api/v1/members/superuser PATCH 200 20ms
INFO  page.clab.api.global.util.ApiLogger - [0:0:0:0:0:0:0:1:test] /api/v1/awards?page=0&size=20&sortBy=awardDate&sortDirection=desc GET 200 9ms
INFO  page.clab.api.global.util.ApiLogger - [0:0:0:0:0:0:0:1:test] /api/v1/awards/2 DELETE 200 13ms
```

## Screenshot

![image](https://github.com/user-attachments/assets/f47d15fa-ebd7-4a37-a126-b72159464d6f)