### PR TITLE
refactor: 게시판 카테고리 재분류 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/community/board/domain/Board.java
+++ b/src/main/java/page/clab/api/domain/community/board/domain/Board.java
@@ -50,10 +50,6 @@ public class Board {
         return this.category.equals(BoardCategory.NOTICE);
     }
 
-    public boolean isGraduated() {
-        return this.category.equals(BoardCategory.GRADUATED);
-    }
-
     public boolean shouldNotifyForNewBoard(MemberDetailedInfoDto memberInfo) {
         return memberInfo.isAdminRole() && this.category.equals(BoardCategory.NOTICE); // Assuming 2 is Admin role level
     }
@@ -71,9 +67,6 @@ public class Board {
     public void validateAccessPermissionForCreation(MemberDetailedInfoDto currentMemberInfo) throws PermissionDeniedException {
         if (this.isNotice() && !currentMemberInfo.isAdminRole()) {
             throw new PermissionDeniedException("공지사항은 관리자만 작성할 수 있습니다.");
-        }
-        if (this.isGraduated() && !currentMemberInfo.isGraduated()) {
-            throw new PermissionDeniedException("졸업생 게시판은 졸업생만 작성할 수 있습니다.");
         }
     }
 }

--- a/src/main/java/page/clab/api/domain/community/board/domain/BoardCategory.java
+++ b/src/main/java/page/clab/api/domain/community/board/domain/BoardCategory.java
@@ -9,8 +9,8 @@ public enum BoardCategory {
 
     NOTICE("notice", "공지사항"),
     FREE("free", "자유 게시판"),
-    QNA("qna", "질문 게시판"),
-    GRADUATED("graduated", "졸업생 게시판"),
+    DEVELOPMENT_QNA("development_qna", "개발 질문 게시판"),
+    INFORMATION_REVIEWS("information_reviews", "정보 및 후기 게시판"),
     ORGANIZATION("organization", "동아리 소식");
 
     private final String key;


### PR DESCRIPTION
## Summary

> #606 

[작업 동기]
사용하지 않는 게시판 카테고리를 삭제하고 용도에 맞게 재분류하교자 합니다. 
이 내용은 2024 C-Lab 운영진의 씨랩 페이지 커뮤니티 활성화 방안 내용 중 백엔드 파트@SongJaeHoonn 프론트 파트 @Jeong-Ag과 함께 작업 계획을 세운 내용입니다.

[작업 내용]
아래와 같은 카테고리로 게시판을 분류합니다.
**공지사항 게시판 (NOTICE)
자유게시판 (FREE)
개발 질문 게시판 (DEVELOPMENT_QNA)
정보 및 후기 게시판 (INFORMATION_REVIEWS)**

따라서 졸업생 게시판과 QnA게시판이 삭제되고
개발질문 게시판과 정보 및 후기 게시판이 생성됩니다.

이때 **QnA 게시판에 등록된 글들은 자유게시판으로 옮기도록 합니다.**

## Tasks

- boardCategory Enum 재설정
 - QnA 게시판의 data 수정 SQL문 작성

## ETC
**QnA 게시판에 등록된 글들을 자유게시판으로 옮기기 위한 SQL문**  

```
UPDATE board
SET category = 'FREE'
WHERE category = 'QNA';

```
**Board 테이블의 제약조건 삭제 후 재설정을 위한 SQL문**
```
ALTER TABLE board
DROP CONSTRAINT board_category_check;

ALTER TABLE board
ADD CONSTRAINT board_category_check 
CHECK (category::text = ANY (ARRAY['NOTICE'::character varying::text, 
                                   'FREE'::character varying::text, 
                                   'DEVELOPMENT_QNA'::character varying::text, 
                                   'INFORMATION_REVIEWS'::character varying::text, 
                                   'ORGANIZATION'::character varying::text]));

```
## Screenshot

<img width="539" alt="image" src="https://github.com/user-attachments/assets/725744a5-634b-4792-b442-7c5f6380f4e1">
