### PR TITLE
refactor : 게시글 이모지와 댓글 좋아요 누르기/취소하기 API 응답 DTO 반환하도록 수정

### DIFF
--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardEmojiToggleController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/BoardEmojiToggleController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import page.clab.api.domain.community.board.application.dto.response.BoardEmojiToggleResponseDto;
 import page.clab.api.domain.community.board.application.port.in.ToggleBoardEmojiUseCase;
 import page.clab.api.global.common.dto.ApiResponse;
 
@@ -22,11 +23,11 @@ public class BoardEmojiToggleController {
     @Operation(summary = "[U] 커뮤니티 게시글 이모지 누르기/취소하기", description = "ROLE_USER 이상의 권한이 필요함")
     @PreAuthorize("hasRole('USER')")
     @PostMapping("/{boardId}/react/{emoji}")
-    public ApiResponse<String> toggleEmojiStatus(
+    public ApiResponse<BoardEmojiToggleResponseDto> toggleEmojiStatus(
             @PathVariable(name = "boardId") Long boardId,
             @PathVariable(name = "emoji") String emoji
     ) {
-        String id = toggleBoardEmojiUseCase.toggleEmojiStatus(boardId, emoji);
-        return ApiResponse.success(id);
+        BoardEmojiToggleResponseDto responseDto = toggleBoardEmojiUseCase.toggleEmojiStatus(boardId, emoji);
+        return ApiResponse.success(responseDto);
     }
 }

--- a/src/main/java/page/clab/api/domain/community/board/application/dto/mapper/BoardDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/dto/mapper/BoardDtoMapper.java
@@ -6,6 +6,7 @@ import page.clab.api.domain.community.board.application.dto.request.BoardRequest
 import page.clab.api.domain.community.board.application.dto.response.BoardCategoryResponseDto;
 import page.clab.api.domain.community.board.application.dto.response.BoardDetailsResponseDto;
 import page.clab.api.domain.community.board.application.dto.response.BoardEmojiCountResponseDto;
+import page.clab.api.domain.community.board.application.dto.response.BoardEmojiToggleResponseDto;
 import page.clab.api.domain.community.board.application.dto.response.BoardListResponseDto;
 import page.clab.api.domain.community.board.application.dto.response.BoardMyResponseDto;
 import page.clab.api.domain.community.board.application.dto.response.WriterInfo;

--- a/src/main/java/page/clab/api/domain/community/board/application/dto/mapper/BoardEmojiDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/dto/mapper/BoardEmojiDtoMapper.java
@@ -1,0 +1,19 @@
+package page.clab.api.domain.community.board.application.dto.mapper;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import page.clab.api.domain.community.board.application.dto.response.BoardEmojiToggleResponseDto;
+import page.clab.api.domain.community.board.domain.BoardEmoji;
+
+@Component
+@RequiredArgsConstructor
+public class BoardEmojiDtoMapper {
+
+    public BoardEmojiToggleResponseDto toDto(BoardEmoji boardEmoji) {
+        return BoardEmojiToggleResponseDto.builder()
+                .boardId(boardEmoji.getBoardId())
+                .emoji(boardEmoji.getEmoji())
+                .isDeleted(boardEmoji.getIsDeleted())
+                .build();
+    }
+}

--- a/src/main/java/page/clab/api/domain/community/board/application/dto/mapper/BoardEmojiDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/dto/mapper/BoardEmojiDtoMapper.java
@@ -1,12 +1,10 @@
 package page.clab.api.domain.community.board.application.dto.mapper;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import page.clab.api.domain.community.board.application.dto.response.BoardEmojiToggleResponseDto;
 import page.clab.api.domain.community.board.domain.BoardEmoji;
 
 @Component
-@RequiredArgsConstructor
 public class BoardEmojiDtoMapper {
 
     public BoardEmojiToggleResponseDto toDto(BoardEmoji boardEmoji) {

--- a/src/main/java/page/clab/api/domain/community/board/application/dto/response/BoardEmojiToggleResponseDto.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/dto/response/BoardEmojiToggleResponseDto.java
@@ -1,0 +1,13 @@
+package page.clab.api.domain.community.board.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BoardEmojiToggleResponseDto {
+
+    private Long boardId;
+    private String emoji;
+    private Boolean isDeleted;
+}

--- a/src/main/java/page/clab/api/domain/community/board/application/port/in/ToggleBoardEmojiUseCase.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/port/in/ToggleBoardEmojiUseCase.java
@@ -1,5 +1,7 @@
 package page.clab.api.domain.community.board.application.port.in;
 
+import page.clab.api.domain.community.board.application.dto.response.BoardEmojiToggleResponseDto;
+
 public interface ToggleBoardEmojiUseCase {
-    String toggleEmojiStatus(Long boardId, String emoji);
+    BoardEmojiToggleResponseDto toggleEmojiStatus(Long boardId, String emoji);
 }

--- a/src/main/java/page/clab/api/domain/community/board/application/service/BoardEmojiToggleService.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/BoardEmojiToggleService.java
@@ -3,6 +3,8 @@ package page.clab.api.domain.community.board.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import page.clab.api.domain.community.board.application.dto.mapper.BoardEmojiDtoMapper;
+import page.clab.api.domain.community.board.application.dto.response.BoardEmojiToggleResponseDto;
 import page.clab.api.domain.community.board.application.port.in.ToggleBoardEmojiUseCase;
 import page.clab.api.domain.community.board.application.port.out.RegisterBoardEmojiPort;
 import page.clab.api.domain.community.board.application.port.out.RetrieveBoardEmojiPort;
@@ -22,6 +24,7 @@ public class BoardEmojiToggleService implements ToggleBoardEmojiUseCase {
     private final RetrieveBoardEmojiPort retrieveBoardEmojiPort;
     private final RegisterBoardEmojiPort registerBoardEmojiPort;
     private final ExternalRetrieveMemberUseCase externalRetrieveMemberUseCase;
+    private final BoardEmojiDtoMapper mapper;
 
     /**
      * 게시글의 이모지 상태를 토글합니다.
@@ -36,7 +39,7 @@ public class BoardEmojiToggleService implements ToggleBoardEmojiUseCase {
      */
     @Transactional
     @Override
-    public String toggleEmojiStatus(Long boardId, String emoji) {
+    public BoardEmojiToggleResponseDto toggleEmojiStatus(Long boardId, String emoji) {
         if (!EmojiUtils.isEmoji(emoji)) {
             throw new InvalidEmojiException("지원하지 않는 이모지입니다.");
         }
@@ -50,6 +53,6 @@ public class BoardEmojiToggleService implements ToggleBoardEmojiUseCase {
                 })
                 .orElseGet(() -> BoardEmoji.create(memberId, boardId, emoji));
         registerBoardEmojiPort.save(boardEmoji);
-        return board.getCategory().getKey();
+        return mapper.toDto(boardEmoji);
     }
 }

--- a/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentLikeToggleController.java
+++ b/src/main/java/page/clab/api/domain/community/comment/adapter/in/web/CommentLikeToggleController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import page.clab.api.domain.community.comment.application.dto.response.CommentLikeToggleResponseDto;
 import page.clab.api.domain.community.comment.application.port.in.ToggleCommentLikeUseCase;
 import page.clab.api.global.common.dto.ApiResponse;
 
@@ -22,10 +23,10 @@ public class CommentLikeToggleController {
     @Operation(summary = "[U] 댓글 좋아요 누르기/취소하기", description = "ROLE_USER 이상의 권한이 필요함")
     @PreAuthorize("hasRole('USER')")
     @PostMapping("/likes/{commentId}")
-    public ApiResponse<Long> toggleLikeStatus(
+    public ApiResponse<CommentLikeToggleResponseDto> toggleLikeStatus(
             @PathVariable(name = "commentId") Long commentId
     ) {
-        Long id = toggleCommentLikeUseCase.toggleLikeStatus(commentId);
-        return ApiResponse.success(id);
+        CommentLikeToggleResponseDto responseDto = toggleCommentLikeUseCase.toggleLikeStatus(commentId);
+        return ApiResponse.success(responseDto);
     }
 }

--- a/src/main/java/page/clab/api/domain/community/comment/application/dto/mapper/CommentLikeDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/community/comment/application/dto/mapper/CommentLikeDtoMapper.java
@@ -1,0 +1,16 @@
+package page.clab.api.domain.community.comment.application.dto.mapper;
+
+import org.springframework.stereotype.Component;
+import page.clab.api.domain.community.comment.application.dto.response.CommentLikeToggleResponseDto;
+
+@Component
+public class CommentLikeDtoMapper {
+
+    public CommentLikeToggleResponseDto toDto(Long boardId, Long commentLikes, Boolean isDeleted) {
+        return CommentLikeToggleResponseDto.builder()
+                .boardId(boardId)
+                .likes(commentLikes)
+                .isDeleted(isDeleted)
+                .build();
+    }
+}

--- a/src/main/java/page/clab/api/domain/community/comment/application/dto/mapper/CommentLikeDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/community/comment/application/dto/mapper/CommentLikeDtoMapper.java
@@ -6,7 +6,7 @@ import page.clab.api.domain.community.comment.application.dto.response.CommentLi
 @Component
 public class CommentLikeDtoMapper {
 
-    public CommentLikeToggleResponseDto toDto(Long boardId, Long commentLikes, Boolean isDeleted) {
+    public CommentLikeToggleResponseDto of(Long boardId, Long commentLikes, Boolean isDeleted) {
         return CommentLikeToggleResponseDto.builder()
                 .boardId(boardId)
                 .likes(commentLikes)

--- a/src/main/java/page/clab/api/domain/community/comment/application/dto/response/CommentLikeToggleResponseDto.java
+++ b/src/main/java/page/clab/api/domain/community/comment/application/dto/response/CommentLikeToggleResponseDto.java
@@ -1,0 +1,15 @@
+package page.clab.api.domain.community.comment.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class CommentLikeToggleResponseDto {
+
+    private Long boardId;
+    private Long likes;
+    private Boolean isDeleted;
+}

--- a/src/main/java/page/clab/api/domain/community/comment/application/port/in/ToggleCommentLikeUseCase.java
+++ b/src/main/java/page/clab/api/domain/community/comment/application/port/in/ToggleCommentLikeUseCase.java
@@ -1,5 +1,7 @@
 package page.clab.api.domain.community.comment.application.port.in;
 
+import page.clab.api.domain.community.comment.application.dto.response.CommentLikeToggleResponseDto;
+
 public interface ToggleCommentLikeUseCase {
-    Long toggleLikeStatus(Long commentId);
+    CommentLikeToggleResponseDto toggleLikeStatus(Long commentId);
 }

--- a/src/main/java/page/clab/api/domain/community/comment/application/service/CommentLikeToggleService.java
+++ b/src/main/java/page/clab/api/domain/community/comment/application/service/CommentLikeToggleService.java
@@ -48,14 +48,14 @@ public class CommentLikeToggleService implements ToggleCommentLikeUseCase {
                     removeCommentLikePort.delete(commentLike);
                     comment.decrementLikes();
                     externalRegisterCommentUseCase.save(comment);
-                    return mapper.toDto(boardId, comment.getLikes(), true);
+                    return mapper.of(boardId, comment.getLikes(), true);
                 })
                 .orElseGet(() -> {
                     CommentLike newLike = CommentLike.create(currentMemberId, comment.getId());
                     registerCommentLikePort.save(newLike);
                     comment.incrementLikes();
                     externalRegisterCommentUseCase.save(comment);
-                    return mapper.toDto(boardId, comment.getLikes(), false);
+                    return mapper.of(boardId, comment.getLikes(), false);
                 });
     }
 }


### PR DESCRIPTION
## Summary

> #633 
게시글 이모지와 누르기/취소하기 API와
댓글 좋아요 누르기/취소하기 API에서 기존 응답 방식을 수정했습니다.

**기존에는 아래와 같이 응답이 되었습니다.**
게시글 이모지 누르기/취소하기 API : board category 반환
댓글 좋아요 누르기/취소하기 API : 댓글의 총 좋아요 개수 반환

**이를 아래와 같이 응답하도록 수정했습니다.**

게시글 이모지 누르기/취소하기 API :
![image](https://github.com/user-attachments/assets/c27e18d4-9d82-4061-9d9c-0bf43ea84ecf)
댓글 좋아요 누르기/취소하기 API :
![image](https://github.com/user-attachments/assets/d3001b92-c90e-47fe-afcd-9b72d2ba5cf3)

## Tasks

 - 게시글 이모지 클릭 토글 API 응답 수정
 - 댓글 좋아요 클릭 토글 API 응답 수정

## ETC
1. 해당 작업에서 CommentLike 테이블의 경우 소프트딜리트가 적용되지 않음을 확인했습니다.
댓글의 좋아요와 게시글의 이모지는 비슷한 로직임에도 게시글의 이모지만 소프트딜리트가 적용되어 있었습니다.
따라서 누르기/취소하기 토글 행위에 대해 어떤 딜리트 방식이 효율적일지 성능 테스트를 #634 에서 진행하고 개선하도록 하겠습니다.

2. @limehee님께서 댓글에서도 좋아요 대신 이모지를 사용하는 것을 제안해주셨습니다. 해당 부분은 members 프로젝트에서 현재 기획한 신규 기능을 마무리하고 추가 회의를 통해 다시 다루도록 @Jeong-Ag 님과 이야기 나눴습니다. 댓글 이모지 기능으로 노선을 수정할 경우, 핫게시글 선정 방식의 수정과 프론트에서 게시글 옆에 [댓글개수]를 표현하는 방식에 대해서도 추가 수정이 필요한 점이 있었습니다. 이러한 이유로 신규 기능 출시를 먼저 하고, 추후 다시 다뤄보도록 하겠습니다. 좋은 의견 감사합니다.