### PR TITLE
refactor : 게시글 이모지 누르기/취소하기 api 응답에서 board category 추가

### DIFF
--- a/src/main/java/page/clab/api/domain/community/board/application/dto/mapper/BoardEmojiDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/dto/mapper/BoardEmojiDtoMapper.java
@@ -7,9 +7,10 @@ import page.clab.api.domain.community.board.domain.BoardEmoji;
 @Component
 public class BoardEmojiDtoMapper {
 
-    public BoardEmojiToggleResponseDto toDto(BoardEmoji boardEmoji) {
+    public BoardEmojiToggleResponseDto toDto(BoardEmoji boardEmoji, String category) {
         return BoardEmojiToggleResponseDto.builder()
                 .boardId(boardEmoji.getBoardId())
+                .category(category)
                 .emoji(boardEmoji.getEmoji())
                 .isDeleted(boardEmoji.getIsDeleted())
                 .build();

--- a/src/main/java/page/clab/api/domain/community/board/application/dto/response/BoardEmojiToggleResponseDto.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/dto/response/BoardEmojiToggleResponseDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public class BoardEmojiToggleResponseDto {
 
     private Long boardId;
+    private String category;
     private String emoji;
     private Boolean isDeleted;
 }

--- a/src/main/java/page/clab/api/domain/community/board/application/service/BoardEmojiToggleService.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/BoardEmojiToggleService.java
@@ -53,6 +53,6 @@ public class BoardEmojiToggleService implements ToggleBoardEmojiUseCase {
                 })
                 .orElseGet(() -> BoardEmoji.create(memberId, boardId, emoji));
         registerBoardEmojiPort.save(boardEmoji);
-        return mapper.toDto(boardEmoji);
+        return mapper.toDto(boardEmoji, board.getCategory().getKey());
     }
 }

--- a/src/main/java/page/clab/api/domain/community/board/domain/BoardCategory.java
+++ b/src/main/java/page/clab/api/domain/community/board/domain/BoardCategory.java
@@ -9,8 +9,8 @@ public enum BoardCategory {
 
     NOTICE("notice", "공지사항"),
     FREE("free", "자유 게시판"),
-    DEVELOPMENT_QNA("development_qna", "개발 질문 게시판"),
-    INFORMATION_REVIEWS("information_reviews", "정보 및 후기 게시판"),
+    DEVELOPMENT_QNA("developmentQna", "개발 질문 게시판"),
+    INFORMATION_REVIEWS("informationReviews", "정보 및 후기 게시판"),
     ORGANIZATION("organization", "동아리 소식");
 
     private final String key;


### PR DESCRIPTION
## Summary

> #638 

@Jeong-Ag 님이 API 연동 중에 요청하신 수정사항 반영했습니다.

## Tasks

- 게시글 이모지 누르기/취소하기 api 응답에 board category 추가


## Screenshot

<img width="281" alt="image" src="https://github.com/user-attachments/assets/3f9777a5-9b01-43ac-bd0a-5d667c8dc590" />