### PR TITLE
refactor : BoardCategory의 key 표현 방식 소문자 + 스네이크로 롤백

### DIFF
--- a/src/main/java/page/clab/api/domain/community/board/domain/BoardCategory.java
+++ b/src/main/java/page/clab/api/domain/community/board/domain/BoardCategory.java
@@ -9,8 +9,8 @@ public enum BoardCategory {
 
     NOTICE("notice", "공지사항"),
     FREE("free", "자유 게시판"),
-    DEVELOPMENT_QNA("developmentQna", "개발 질문 게시판"),
-    INFORMATION_REVIEWS("informationReviews", "정보 및 후기 게시판"),
+    DEVELOPMENT_QNA("development_qna", "개발 질문 게시판"),
+    INFORMATION_REVIEWS("information_reviews", "정보 및 후기 게시판"),
     ORGANIZATION("organization", "동아리 소식");
 
     private final String key;


### PR DESCRIPTION
## Summary

> #640 

#609  이후로 백엔드에서 관리하는 ENUM의 key 값은 대문자 + 스네이크로 통일할 예정입니다. 현재는 진행 중인 연동 작업 때문에 BoardCategory의 key 표현만 소문자 + 스네이크로 잠시 롤백합니다.

## Tasks

- BoardCategory의 key 표현 방식 소문자 + 스네이크로 롤백


