### PR TITLE
refactor: 해시태그에 카테고리 적용 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/community/board/adapter/in/web/HotBoardsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/in/web/HotBoardsRetrievalController.java
@@ -2,6 +2,7 @@ package page.clab.api.domain.community.board.adapter.in.web;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,8 +12,6 @@ import org.springframework.web.bind.annotation.RestController;
 import page.clab.api.domain.community.board.application.dto.response.BoardListResponseDto;
 import page.clab.api.domain.community.board.application.port.in.RetrieveHotBoardsUseCase;
 import page.clab.api.global.common.dto.ApiResponse;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/boards")

--- a/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardPersistenceAdapter.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/BoardPersistenceAdapter.java
@@ -1,5 +1,8 @@
 package page.clab.api.domain.community.board.adapter.out.persistence;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,10 +12,6 @@ import page.clab.api.domain.community.board.application.port.out.RetrieveBoardPo
 import page.clab.api.domain.community.board.domain.Board;
 import page.clab.api.domain.community.board.domain.BoardCategory;
 import page.clab.api.global.exception.NotFoundException;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/RedisHotBoardPersistenceAdapter.java
+++ b/src/main/java/page/clab/api/domain/community/board/adapter/out/persistence/RedisHotBoardPersistenceAdapter.java
@@ -1,15 +1,14 @@
 package page.clab.api.domain.community.board.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import page.clab.api.domain.community.board.application.port.out.RegisterHotBoardPort;
 import page.clab.api.domain.community.board.application.port.out.RemoveHotBoardPort;
 import page.clab.api.domain.community.board.application.port.out.RetrieveHotBoardPort;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/page/clab/api/domain/community/board/application/dto/mapper/BoardDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/dto/mapper/BoardDtoMapper.java
@@ -7,7 +7,6 @@ import page.clab.api.domain.community.board.application.dto.request.BoardRequest
 import page.clab.api.domain.community.board.application.dto.response.BoardDetailsResponseDto;
 import page.clab.api.domain.community.board.application.dto.response.BoardEmojiCountResponseDto;
 import page.clab.api.domain.community.board.application.dto.response.BoardHashtagResponseDto;
-import page.clab.api.domain.community.board.application.dto.response.BoardEmojiToggleResponseDto;
 import page.clab.api.domain.community.board.application.dto.response.BoardListResponseDto;
 import page.clab.api.domain.community.board.application.dto.response.BoardMyResponseDto;
 import page.clab.api.domain.community.board.application.dto.response.BoardOverviewResponseDto;

--- a/src/main/java/page/clab/api/domain/community/board/application/port/in/RetrieveHotBoardsUseCase.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/port/in/RetrieveHotBoardsUseCase.java
@@ -1,8 +1,7 @@
 package page.clab.api.domain.community.board.application.port.in;
 
-import page.clab.api.domain.community.board.application.dto.response.BoardListResponseDto;
-
 import java.util.List;
+import page.clab.api.domain.community.board.application.dto.response.BoardListResponseDto;
 
 public interface RetrieveHotBoardsUseCase {
     List<BoardListResponseDto> retrieveHotBoards(String strategyName);

--- a/src/main/java/page/clab/api/domain/community/board/application/port/out/RetrieveBoardPort.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/port/out/RetrieveBoardPort.java
@@ -1,12 +1,11 @@
 package page.clab.api.domain.community.board.application.port.out;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import page.clab.api.domain.community.board.domain.Board;
 import page.clab.api.domain.community.board.domain.BoardCategory;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 public interface RetrieveBoardPort {
 

--- a/src/main/java/page/clab/api/domain/community/board/application/service/DefaultHotBoardSelectionStrategy.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/DefaultHotBoardSelectionStrategy.java
@@ -1,5 +1,11 @@
 package page.clab.api.domain.community.board.application.service;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,13 +13,6 @@ import page.clab.api.domain.community.board.application.port.out.RetrieveBoardEm
 import page.clab.api.domain.community.board.application.port.out.RetrieveBoardPort;
 import page.clab.api.domain.community.board.domain.Board;
 import page.clab.api.external.community.comment.application.port.ExternalRetrieveCommentUseCase;
-
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service(HotBoardSelectionStrategies.DEFAULT)
 @RequiredArgsConstructor

--- a/src/main/java/page/clab/api/domain/community/board/application/service/HotBoardRegisterService.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/HotBoardRegisterService.java
@@ -1,5 +1,7 @@
 package page.clab.api.domain.community.board.application.service;
 
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -7,9 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import page.clab.api.domain.community.board.application.port.out.RegisterHotBoardPort;
 import page.clab.api.domain.community.board.application.port.out.RemoveHotBoardPort;
 import page.clab.api.domain.community.board.domain.Board;
-
-import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/page/clab/api/domain/community/board/application/service/HotBoardRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/HotBoardRetrievalService.java
@@ -2,6 +2,8 @@ package page.clab.api.domain.community.board.application.service;
 
 import com.drew.lang.annotations.NotNull;
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import page.clab.api.domain.community.board.application.dto.mapper.BoardDtoMapper;
@@ -14,9 +16,6 @@ import page.clab.api.domain.community.board.domain.Board;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberDetailedInfoDto;
 import page.clab.api.external.community.comment.application.port.ExternalRetrieveCommentUseCase;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
-
-import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/page/clab/api/domain/community/board/application/service/HotBoardSelectionStrategy.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/HotBoardSelectionStrategy.java
@@ -1,8 +1,7 @@
 package page.clab.api.domain.community.board.application.service;
 
-import page.clab.api.domain.community.board.domain.Board;
-
 import java.util.List;
+import page.clab.api.domain.community.board.domain.Board;
 
 public interface HotBoardSelectionStrategy {
     List<Board> getHotBoards();

--- a/src/main/java/page/clab/api/domain/community/hashtag/adapter/in/web/HashtagRegisterController.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/adapter/in/web/HashtagRegisterController.java
@@ -27,7 +27,7 @@ public class HashtagRegisterController {
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("")
     public ApiResponse<List<HashtagResponseDto>> registerHashtag(
-        @Valid @RequestBody HashtagRequestDto requestDto
+        @Valid @RequestBody List<HashtagRequestDto> requestDto
     ) {
         List<HashtagResponseDto> hashTags = registerHashtagUseCase.registerHashtag(requestDto);
         return ApiResponse.success(hashTags);

--- a/src/main/java/page/clab/api/domain/community/hashtag/adapter/out/persistence/HashtagJpaEntity.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/adapter/out/persistence/HashtagJpaEntity.java
@@ -2,6 +2,8 @@ package page.clab.api.domain.community.hashtag.adapter.out.persistence;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -14,6 +16,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+import page.clab.api.domain.community.hashtag.domain.HashtagCategory;
 import page.clab.api.global.common.domain.BaseEntity;
 
 @Entity
@@ -33,6 +36,10 @@ public class HashtagJpaEntity extends BaseEntity {
 
     @Column(name = "name", unique = true, nullable = false)
     private String name;
+
+    @Column(name = "hashtag_category", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private HashtagCategory hashtagCategory;
 
     @Column(name = "board_usage", nullable = false)
     private Long boardUsage;

--- a/src/main/java/page/clab/api/domain/community/hashtag/application/dto/mapper/HashtagDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/application/dto/mapper/HashtagDtoMapper.java
@@ -4,14 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import page.clab.api.domain.community.hashtag.application.dto.response.HashtagResponseDto;
 import page.clab.api.domain.community.hashtag.domain.Hashtag;
+import page.clab.api.domain.community.hashtag.domain.HashtagCategory;
 
 @Component
 @RequiredArgsConstructor
 public class HashtagDtoMapper {
 
-    public Hashtag of(String name) {
+    public Hashtag of(String name, HashtagCategory hashtagCategory) {
         return Hashtag.builder()
             .name(name)
+            .hashtagCategory(hashtagCategory)
             .boardUsage(0L)
             .isDeleted(false)
             .build();
@@ -21,6 +23,7 @@ public class HashtagDtoMapper {
         return HashtagResponseDto.builder()
             .id(hashtag.getId())
             .name(hashtag.getName())
+            .hashtagCategory(hashtag.getHashtagCategory().getKey())
             .boardUsageCount(hashtag.getBoardUsage())
             .build();
     }

--- a/src/main/java/page/clab/api/domain/community/hashtag/application/dto/request/HashtagRequestDto.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/application/dto/request/HashtagRequestDto.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
+import page.clab.api.domain.community.hashtag.domain.HashtagCategory;
 
 @Getter
 @Setter
 public class HashtagRequestDto {
 
-    List<String> hashtagNames = new ArrayList<>();
+    private String name;
+    private HashtagCategory hashtagCategory;
 }

--- a/src/main/java/page/clab/api/domain/community/hashtag/application/dto/request/HashtagRequestDto.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/application/dto/request/HashtagRequestDto.java
@@ -1,7 +1,5 @@
 package page.clab.api.domain.community.hashtag.application.dto.request;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import page.clab.api.domain.community.hashtag.domain.HashtagCategory;

--- a/src/main/java/page/clab/api/domain/community/hashtag/application/dto/response/HashtagResponseDto.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/application/dto/response/HashtagResponseDto.java
@@ -2,6 +2,7 @@ package page.clab.api.domain.community.hashtag.application.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import page.clab.api.domain.community.hashtag.domain.HashtagCategory;
 
 @Getter
 @Builder
@@ -9,5 +10,6 @@ public class HashtagResponseDto {
 
     private Long id;
     private String name;
+    private String hashtagCategory;
     private Long boardUsageCount;
 }

--- a/src/main/java/page/clab/api/domain/community/hashtag/application/dto/response/HashtagResponseDto.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/application/dto/response/HashtagResponseDto.java
@@ -2,7 +2,6 @@ package page.clab.api.domain.community.hashtag.application.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import page.clab.api.domain.community.hashtag.domain.HashtagCategory;
 
 @Getter
 @Builder

--- a/src/main/java/page/clab/api/domain/community/hashtag/application/port/in/RegisterHashtagUseCase.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/application/port/in/RegisterHashtagUseCase.java
@@ -6,5 +6,5 @@ import page.clab.api.domain.community.hashtag.application.dto.response.HashtagRe
 
 public interface RegisterHashtagUseCase {
 
-    List<HashtagResponseDto> registerHashtag(HashtagRequestDto requestDto);
+    List<HashtagResponseDto> registerHashtag(List<HashtagRequestDto> requestDto);
 }

--- a/src/main/java/page/clab/api/domain/community/hashtag/application/service/HashtagRegisterService.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/application/service/HashtagRegisterService.java
@@ -11,6 +11,7 @@ import page.clab.api.domain.community.hashtag.application.port.in.RegisterHashta
 import page.clab.api.domain.community.hashtag.application.port.in.RetrieveHashtagUseCase;
 import page.clab.api.domain.community.hashtag.application.port.out.RegisterHashtagPort;
 import page.clab.api.domain.community.hashtag.domain.Hashtag;
+import page.clab.api.domain.community.hashtag.domain.HashtagCategory;
 
 @Service
 @RequiredArgsConstructor
@@ -21,16 +22,18 @@ public class HashtagRegisterService implements RegisterHashtagUseCase {
     private final HashtagDtoMapper mapper;
 
     @Override
-    public List<HashtagResponseDto> registerHashtag(HashtagRequestDto requestDto) {
-        List<HashtagResponseDto> savedHashtagId = new ArrayList<>();
-        for (String name : requestDto.getHashtagNames()) {
+    public List<HashtagResponseDto> registerHashtag(List<HashtagRequestDto> requestDtos) {
+        List<HashtagResponseDto> savedHashtag = new ArrayList<>();
+        for (HashtagRequestDto requestDto : requestDtos) {
+            String name = requestDto.getName();
+            HashtagCategory hashtagCategory = requestDto.getHashtagCategory();
             if (retrieveHashtagUseCase.existsByName(name)) {
-                savedHashtagId.add(mapper.toDto(retrieveHashtagUseCase.getByName(name)));
+                savedHashtag.add(mapper.toDto(retrieveHashtagUseCase.getByName(name)));
             } else {
-                Hashtag hashtag = mapper.of(name);
-                savedHashtagId.add(mapper.toDto(registerHashtagPort.save(hashtag)));
+                Hashtag hashtag = mapper.of(name, hashtagCategory);
+                savedHashtag.add(mapper.toDto(registerHashtagPort.save(hashtag)));
             }
         }
-        return savedHashtagId;
+        return savedHashtag;
     }
 }

--- a/src/main/java/page/clab/api/domain/community/hashtag/domain/Hashtag.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/domain/Hashtag.java
@@ -16,6 +16,7 @@ public class Hashtag {
 
     Long id;
     String name;
+    HashtagCategory hashtagCategory;
     Boolean isDeleted;
     Long boardUsage;
 

--- a/src/main/java/page/clab/api/domain/community/hashtag/domain/HashtagCategory.java
+++ b/src/main/java/page/clab/api/domain/community/hashtag/domain/HashtagCategory.java
@@ -1,0 +1,17 @@
+package page.clab.api.domain.community.hashtag.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum HashtagCategory {
+
+    LANGUAGE("LANGUAGE", "언어"),
+    FIELD("FIELD", "분야"),
+    SKILL("SKILL", "기술"),
+    ETC("ETC", "기타");
+
+    private final String key;
+    private final String description;
+}


### PR DESCRIPTION
## Summary

> #646 

20가지 정도 되던 해시태그를 분류할 수 있도록 카테고리를 생성해서 관리하도록 했습니다.
@Jeong-Ag 님이 UX적인 요소를 고려해서 제안해 주신 내용입니다.

## Tasks

- 해시태그 카테고리 설정하기

## SQL

```sql
DELETE FROM hashtag;
```

```sql
ALTER TABLE hashtag
ADD COLUMN hashtag_category VARCHAR(50) NOT NULL DEFAULT 'ETC';
```

```sql
INSERT INTO hashtag (name, category, is_deleted, board_usage, created_at, updated_at) VALUES

('C', 'LANGUAGE', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('C++', 'LANGUAGE', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Java', 'LANGUAGE', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Javascript', 'LANGUAGE', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Python', 'LANGUAGE', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Assembly', 'LANGUAGE', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Kotlin', 'LANGUAGE', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Typescript', 'LANGUAGE', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),


('Front-end', 'FIELD', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Back-end', 'FIELD', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('AI', 'FIELD', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Game', 'FIELD', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Android', 'FIELD', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('IOS', 'FIELD', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),


('DB', 'SKILL', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Devops', 'SKILL', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('Infra', 'SKILL', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('framework', 'SKILL', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
('algorithm', 'SKILL', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),

('기타', 'ETC', false, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
```
## Screenshot

<img width="682" alt="image" src="https://github.com/user-attachments/assets/39ec3dc7-d1b7-4b0d-88e9-33b7fb37ff99" />

