### PR TITLE
refactor: 운영진 정보 조회 API 권한 변경 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/memberManagement/executive/adapter/in/web/ExecutiveRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/executive/adapter/in/web/ExecutiveRetrievalController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,8 +19,7 @@ public class ExecutiveRetrievalController {
 
     private final RetrieveExecutiveUseCase retrieveExecutiveUseCase;
 
-    @Operation(summary = "[G] 운영진 정보 조회", description = "ROLE_GUEST 이상의 권한이 필요함")
-    @PreAuthorize("hasRole('GUEST')")
+    @Operation(summary = "운영진 정보 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함")
     @GetMapping("")
     public ApiResponse<List<ExecutiveResponseDto>> retrieveExecutives() {
         List<ExecutiveResponseDto> executives = retrieveExecutiveUseCase.retrieveExecutives();

--- a/src/main/java/page/clab/api/global/config/SecurityConstants.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConstants.java
@@ -26,7 +26,8 @@ public class SecurityConstants {
         "/api/v1/work-experiences", "/api/v1/work-experiences/**",
         "/api/v1/products", "/api/v1/products/**",
         "/api/v1/reviews", "/api/v1/reviews/**",
-        "/api/v1/activity-photos", "/api/v1/activity-photos/**"
+        "/api/v1/activity-photos", "/api/v1/activity-photos/**",
+        "/api/v1/executive"
     };
 
     public static final String[] PERMIT_ALL_API_ENDPOINTS_POST = {


### PR DESCRIPTION
## Summary

> #653 

운영진 정보 조회 API의 요청 권한을 `GUEST`에서 `ANONYMOUS`로 변경했습니다.

## Tasks

- 운영진 정보 조회 권한 변경


## Screenshot

<img width="623" alt="스크린샷 2025-01-10 오후 12 49 14" src="https://github.com/user-attachments/assets/2b43ce52-0687-483f-916d-a6a4b42c5caf" />

