### PR TITLE
feat: 현재 모집중인 모집공고 목록 조회 기능 구현 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/OpenRecruitmentsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/OpenRecruitmentsRetrievalController.java
@@ -1,0 +1,28 @@
+package page.clab.api.domain.hiring.recruitment.adapter.in.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentOpenResponseDto;
+import page.clab.api.domain.hiring.recruitment.application.port.in.RetrieveOpenRecruitmentsUseCase;
+import page.clab.api.global.common.dto.ApiResponse;
+
+@RestController
+@RequestMapping("/api/v1/recruitments")
+@RequiredArgsConstructor
+@Tag(name = "Hiring - Recruitment", description = "모집 공고")
+public class OpenRecruitmentsRetrievalController {
+
+    private final RetrieveOpenRecruitmentsUseCase retrieveOpenRecruitmentsUseCase;
+
+    @Operation(summary = "현재 모집 중인 모집 공고 목록", description = "ROLE_ANONYMOUS 이상의 권한이 필요함")
+    @GetMapping("/open")
+    public ApiResponse<List<RecruitmentOpenResponseDto>> retrieveRecruitmentsByEndDate() {
+        List<RecruitmentOpenResponseDto> recruitments = retrieveOpenRecruitmentsUseCase.retrieveOpenRecruitments();
+        return ApiResponse.success(recruitments);
+    }
+}

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/OpenRecruitmentsRetrievalController.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/OpenRecruitmentsRetrievalController.java
@@ -21,7 +21,7 @@ public class OpenRecruitmentsRetrievalController {
 
     @Operation(summary = "현재 모집 중인 모집 공고 목록", description = "ROLE_ANONYMOUS 이상의 권한이 필요함")
     @GetMapping("/open")
-    public ApiResponse<List<RecruitmentOpenResponseDto>> retrieveRecruitmentsByEndDate() {
+    public ApiResponse<List<RecruitmentOpenResponseDto>> retrieveOpenRecruitments() {
         List<RecruitmentOpenResponseDto> recruitments = retrieveOpenRecruitmentsUseCase.retrieveOpenRecruitments();
         return ApiResponse.success(recruitments);
     }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/out/persistence/RecruitmentPersistenceAdapter.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/out/persistence/RecruitmentPersistenceAdapter.java
@@ -8,6 +8,7 @@ import page.clab.api.domain.hiring.recruitment.application.port.out.RegisterRecr
 import page.clab.api.domain.hiring.recruitment.application.port.out.RetrieveRecruitmentPort;
 import page.clab.api.domain.hiring.recruitment.application.port.out.UpdateRecruitmentPort;
 import page.clab.api.domain.hiring.recruitment.domain.Recruitment;
+import page.clab.api.domain.hiring.recruitment.domain.RecruitmentStatus;
 import page.clab.api.global.exception.NotFoundException;
 
 @Component
@@ -59,6 +60,13 @@ public class RecruitmentPersistenceAdapter implements
     @Override
     public List<Recruitment> findByEndDateBetween(LocalDateTime weekAgo, LocalDateTime now) {
         return repository.findByEndDateBetween(weekAgo, now).stream()
+            .map(mapper::toDomain)
+            .toList();
+    }
+
+    @Override
+    public List<Recruitment> findByStatus(RecruitmentStatus status) {
+        return repository.findByStatus(status).stream()
             .map(mapper::toDomain)
             .toList();
     }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/out/persistence/RecruitmentRepository.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/out/persistence/RecruitmentRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import page.clab.api.domain.hiring.recruitment.domain.RecruitmentStatus;
 
 @Repository
 public interface RecruitmentRepository extends JpaRepository<RecruitmentJpaEntity, Long> {
@@ -11,4 +12,6 @@ public interface RecruitmentRepository extends JpaRepository<RecruitmentJpaEntit
     List<RecruitmentJpaEntity> findTop5ByOrderByCreatedAtDesc();
 
     List<RecruitmentJpaEntity> findByEndDateBetween(LocalDateTime weekAgo, LocalDateTime now);
+
+    List<RecruitmentJpaEntity> findByStatus(RecruitmentStatus status);
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/dto/mapper/RecruitmentDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/dto/mapper/RecruitmentDtoMapper.java
@@ -2,6 +2,7 @@ package page.clab.api.domain.hiring.recruitment.application.dto.mapper;
 
 import org.springframework.stereotype.Component;
 import page.clab.api.domain.hiring.recruitment.application.dto.request.RecruitmentRequestDto;
+import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentOpenResponseDto;
 import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentDetailsResponseDto;
 import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentEndDateResponseDto;
 import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentResponseDto;
@@ -57,6 +58,13 @@ public class RecruitmentDtoMapper {
             .target(recruitment.getTarget())
             .status(recruitment.getStatus().getDescription())
             .updatedAt(recruitment.getUpdatedAt())
+            .build();
+    }
+
+    public RecruitmentOpenResponseDto toOpenDto(Recruitment recruitment) {
+        return RecruitmentOpenResponseDto.builder()
+            .id(recruitment.getId())
+            .applicationType(recruitment.getApplicationType())
             .build();
     }
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/dto/response/RecruitmentOpenResponseDto.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/dto/response/RecruitmentOpenResponseDto.java
@@ -1,0 +1,13 @@
+package page.clab.api.domain.hiring.recruitment.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import page.clab.api.domain.hiring.application.domain.ApplicationType;
+
+@Getter
+@Builder
+public class RecruitmentOpenResponseDto {
+
+    private Long id;
+    private ApplicationType applicationType;
+}

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/port/in/RetrieveOpenRecruitmentsUseCase.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/port/in/RetrieveOpenRecruitmentsUseCase.java
@@ -1,0 +1,8 @@
+package page.clab.api.domain.hiring.recruitment.application.port.in;
+
+import java.util.List;
+import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentOpenResponseDto;
+
+public interface RetrieveOpenRecruitmentsUseCase {
+    List<RecruitmentOpenResponseDto> retrieveOpenRecruitments();
+}

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/port/out/RetrieveRecruitmentPort.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/port/out/RetrieveRecruitmentPort.java
@@ -3,6 +3,7 @@ package page.clab.api.domain.hiring.recruitment.application.port.out;
 import java.time.LocalDateTime;
 import java.util.List;
 import page.clab.api.domain.hiring.recruitment.domain.Recruitment;
+import page.clab.api.domain.hiring.recruitment.domain.RecruitmentStatus;
 
 public interface RetrieveRecruitmentPort {
 
@@ -13,4 +14,6 @@ public interface RetrieveRecruitmentPort {
     List<Recruitment> findTop5ByOrderByCreatedAtDesc();
 
     List<Recruitment> findByEndDateBetween(LocalDateTime weekAgo, LocalDateTime now);
+
+    List<Recruitment> findByStatus(RecruitmentStatus status);
 }

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/service/OpenRecruitmentsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/service/OpenRecruitmentsRetrievalService.java
@@ -1,0 +1,27 @@
+package page.clab.api.domain.hiring.recruitment.application.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import page.clab.api.domain.hiring.recruitment.application.dto.mapper.RecruitmentDtoMapper;
+import page.clab.api.domain.hiring.recruitment.application.dto.response.RecruitmentOpenResponseDto;
+import page.clab.api.domain.hiring.recruitment.application.port.in.RetrieveOpenRecruitmentsUseCase;
+import page.clab.api.domain.hiring.recruitment.application.port.out.RetrieveRecruitmentPort;
+import page.clab.api.domain.hiring.recruitment.domain.RecruitmentStatus;
+
+@Service
+@RequiredArgsConstructor
+public class OpenRecruitmentsRetrievalService implements RetrieveOpenRecruitmentsUseCase {
+
+    private final RetrieveRecruitmentPort retrieveRecruitmentPort;
+    private final RecruitmentDtoMapper mapper;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<RecruitmentOpenResponseDto> retrieveOpenRecruitments() {
+        return retrieveRecruitmentPort.findByStatus(RecruitmentStatus.OPEN).stream()
+            .map(mapper::toOpenDto)
+            .toList();
+    }
+}

--- a/src/main/java/page/clab/api/global/config/SecurityConstants.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConstants.java
@@ -18,7 +18,7 @@ public class SecurityConstants {
     public static final String[] PERMIT_ALL_API_ENDPOINTS_GET = {
         "/api/v1/applications/{recruitmentId}/{studentId}",
         "/api/v1/recruitments", "/api/v1/recruitments/recent-week",
-        "/api/v1/recruitments/{recruitmentId}",
+        "/api/v1/recruitments/{recruitmentId}", "/api/v1/recruitments/open",
         "/api/v1/news", "/api/v1/news/**",
         "/api/v1/blogs", "/api/v1/blogs/**",
         "/api/v1/positions", "/api/v1/positions/**",


### PR DESCRIPTION
## Summary

> #657 

현재 모집 중인(`RecruitmentStatus.OPEN`) 모집 공고들을 조회할 수 있는 기능을 구현했습니다.

## Tasks

- 현재 모집중인 모집공고 목록 조회 API 작성

## Screenshot

- 모집 종료일이 지나지 않았을 때
<img width="473" alt="스크린샷 2025-01-14 오후 5 12 29" src="https://github.com/user-attachments/assets/c58f8ebc-c0cc-401a-9339-bbcf8028e289" />

- 새로운 모집 공고를 추가했을 때
<img width="382" alt="스크린샷 2025-01-14 오후 5 15 04" src="https://github.com/user-attachments/assets/89470115-120a-4dcb-9cfc-9706a13e373e" />

