### PR TITLE
feat: 모집 공고 삭제 기능 구현 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/RecruitmentRemoveController.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/RecruitmentRemoveController.java
@@ -1,0 +1,31 @@
+package page.clab.api.domain.hiring.recruitment.adapter.in.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import page.clab.api.domain.hiring.recruitment.application.port.in.RemoveRecruitmentUseCase;
+import page.clab.api.global.common.dto.ApiResponse;
+
+@RestController
+@RequestMapping("/api/v1/recruitments")
+@RequiredArgsConstructor
+@Tag(name = "Hiring - Recruitment", description = "모집 공고")
+public class RecruitmentRemoveController {
+
+    private final RemoveRecruitmentUseCase removeRecruitmentUseCase;
+
+    @Operation(summary = "[S] 모집 공고 삭제", description = "ROLE_SUPER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('SUPER')")
+    @DeleteMapping("/{recruitmentId}")
+    public ApiResponse<Long> removeBoard(
+        @PathVariable(name = "recruitmentId") Long recruitmentId
+    ) {
+        Long id = removeRecruitmentUseCase.removeRecruitment(recruitmentId);
+        return ApiResponse.success(id);
+    }
+}

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/RecruitmentRemoveController.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/adapter/in/web/RecruitmentRemoveController.java
@@ -22,7 +22,7 @@ public class RecruitmentRemoveController {
     @Operation(summary = "[S] 모집 공고 삭제", description = "ROLE_SUPER 이상의 권한이 필요함")
     @PreAuthorize("hasRole('SUPER')")
     @DeleteMapping("/{recruitmentId}")
-    public ApiResponse<Long> removeBoard(
+    public ApiResponse<Long> removeRecruitment(
         @PathVariable(name = "recruitmentId") Long recruitmentId
     ) {
         Long id = removeRecruitmentUseCase.removeRecruitment(recruitmentId);

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/port/in/RemoveRecruitmentUseCase.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/port/in/RemoveRecruitmentUseCase.java
@@ -1,0 +1,5 @@
+package page.clab.api.domain.hiring.recruitment.application.port.in;
+
+public interface RemoveRecruitmentUseCase {
+    Long removeRecruitment(Long recruitmentId);
+}

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/application/service/RecruitmentRemoveService.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/application/service/RecruitmentRemoveService.java
@@ -1,0 +1,25 @@
+package page.clab.api.domain.hiring.recruitment.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import page.clab.api.domain.hiring.recruitment.application.port.in.RemoveRecruitmentUseCase;
+import page.clab.api.domain.hiring.recruitment.application.port.out.RegisterRecruitmentPort;
+import page.clab.api.domain.hiring.recruitment.application.port.out.RetrieveRecruitmentPort;
+import page.clab.api.domain.hiring.recruitment.domain.Recruitment;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitmentRemoveService implements RemoveRecruitmentUseCase {
+
+    private final RetrieveRecruitmentPort retrieveRecruitmentPort;
+    private final RegisterRecruitmentPort registerRecruitmentPort;
+
+    @Transactional
+    @Override
+    public Long removeRecruitment(Long recruitmentId) {
+        Recruitment recruitment = retrieveRecruitmentPort.getById(recruitmentId);
+        recruitment.delete();
+        return registerRecruitmentPort.save(recruitment).getId();
+    }
+}

--- a/src/main/java/page/clab/api/domain/hiring/recruitment/domain/Recruitment.java
+++ b/src/main/java/page/clab/api/domain/hiring/recruitment/domain/Recruitment.java
@@ -46,6 +46,10 @@ public class Recruitment {
         Optional.ofNullable(recruitmentUpdateRequestDto.getTarget()).ifPresent(this::setTarget);
     }
 
+    public void delete() {
+        this.isDeleted = true;
+    }
+
     public void updateStatus(RecruitmentStatus status) {
         this.status = status;
     }


### PR DESCRIPTION
## Summary

> #659 

모집 공고 id를 받아 삭제하는 기능을 구현했습니다.

## Tasks

- 모집공고 id로 삭제하기 API 작성


## Screenshot

- 삭제 전 모집 공고 조회
<img width="427" alt="스크린샷 2025-01-18 오후 2 52 48" src="https://github.com/user-attachments/assets/2ddf76be-a02b-4477-aeb4-e304b403c2df" />

- id 3번 삭제 후 모집 공고 조회
<img width="409" alt="스크린샷 2025-01-18 오후 2 53 47" src="https://github.com/user-attachments/assets/882b6d25-5a3c-4eda-87da-768b2ff78f94" />
