### PR TITLE
refactor: 운영진 사진 업로드 디렉토리 구조 변경 완료

### DIFF
--- a/src/main/java/page/clab/api/global/common/file/api/FileController.java
+++ b/src/main/java/page/clab/api/global/common/file/api/FileController.java
@@ -56,12 +56,14 @@ public class FileController {
 
     @Operation(summary = "[A] 운영진 사진 업로드", description = "ROLE_ADMIN 이상의 권한이 필요함")
     @PreAuthorize("hasRole('ADMIN')")
-    @PostMapping(value = "/executives", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/executives/{executiveId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces =
+        MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<UploadedFileResponseDto> executiveUpload(
+        @PathVariable(name = "executiveId") Long executiveId,
         @RequestParam(name = "multipartFile") MultipartFile multipartFile,
         @RequestParam(name = "storagePeriod") long storagePeriod
     ) throws IOException, PermissionDeniedException {
-        String path = fileService.buildPath("executives");
+        String path = fileService.buildPath("executives", executiveId);
         UploadedFileResponseDto responseDto = fileService.saveFile(multipartFile, path, storagePeriod);
         return ApiResponse.success(responseDto);
     }

--- a/src/main/java/page/clab/api/global/common/file/application/FileService.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileService.java
@@ -172,6 +172,9 @@ public class FileService {
         for (Long segment : additionalSegments) {
             pathBuilder.append(File.separator).append(segment);
         }
+        if (checkExecutivesDirectory(baseDirectory)) {
+            return pathBuilder.toString();
+        }
         pathBuilder.append(File.separator).append(currentMemberId);
         return pathBuilder.toString();
     }
@@ -194,6 +197,10 @@ public class FileService {
                 validateSubmitPath(pathParts);
                 break;
         }
+    }
+
+    private boolean checkExecutivesDirectory(String baseDirectory) {
+        return baseDirectory.equals("executives");
     }
 
     private void validateNoticePath(String[] pathParts) throws InvalidPathVariableException, PermissionDeniedException {


### PR DESCRIPTION
## Summary

> #661 

운영진 사진 업로드 경로를 다음과 같이 변경했습니다.
기존 : `/executives/{currentUserId}/`
변경 후 : `/executives/{executiveId}/`

## Tasks

- 경로 생성시 `executives` 디렉토리인지 체크 
- 운영진 사진 저장 디렉토리 구조 변경

## ETC

운영진 사진을 한번에 받아 한 명이 전부 등록할 때, 사진이 삭제되지 않고 운영진 학번으로 저장됩니다.

## Screenshot

<img width="461" alt="스크린샷 2025-01-19 오전 12 12 05" src="https://github.com/user-attachments/assets/6ef5155f-09ec-4099-84ed-47b394aad205" />
