### PR TITLE
refactor : 이달의 생일자 조회 시 관리자와 게스트 정보 제외 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepositoryImpl.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepositoryImpl.java
@@ -77,7 +77,8 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 birthdayInMonth(month)
                     .and(qMember.name.ne("관리자"))
                     .and(qMember.role.ne(Role.GUEST))
-            )            .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+            )
+            .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepositoryImpl.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepositoryImpl.java
@@ -75,7 +75,6 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
             .selectFrom(qMember)
             .where(
                 birthdayInMonth(month)
-                    .and(qMember.name.ne("관리자"))
                     .and(qMember.role.ne(Role.GUEST))
             )
             .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))

--- a/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepositoryImpl.java
+++ b/src/main/java/page/clab/api/domain/memberManagement/member/adapter/out/persistence/MemberRepositoryImpl.java
@@ -73,8 +73,11 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
 
         List<MemberJpaEntity> members = queryFactory
             .selectFrom(qMember)
-            .where(birthdayInMonth(month))
-            .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+            .where(
+                birthdayInMonth(month)
+                    .and(qMember.name.ne("관리자"))
+                    .and(qMember.role.ne(Role.GUEST))
+            )            .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();


### PR DESCRIPTION
## Summary
#665

이달의 생일자 조회 시 관리자와 게스트 정보는 제외하도록 where 구문을 수정했습니다.
## Tasks

- 이달의 생일자 조회 시 관리자와 게스트 정보 제외

## ETC

실제 서버의 data를 dump 하여 테스트를 진행했습니다.
원래는 아래처럼 관리자와 방문자가 맨 앞에 조회 되었으나 Screenshot에 첨부된 JSON 응답 처럼 실제 멤버부터 조회되는 것을 확인 할 수 있습니다.

![image](https://github.com/user-attachments/assets/309d411a-e8e8-48d2-9516-883ca3086dad)

## Screenshot
<img width="236" alt="image" src="https://github.com/user-attachments/assets/88eaee32-ac11-4c2b-9935-41586116cb60" />

