### PR TITLE
fix: 자신이 쓴 BUG 카테고리 문의 게시글의 상세 조회 접근이 불가능해지는 문제 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/members/support/application/service/SupportDetailsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/members/support/application/service/SupportDetailsRetrievalService.java
@@ -45,7 +45,11 @@ public class SupportDetailsRetrievalService implements RetrieveSupportDetailsUse
     }
 
     private void validateAccessible(MemberDetailedInfoDto memberInfo, Support support) {
-        if(!memberInfo.getMemberId().equals(support.getMemberId()) && !memberInfo.isAdminRole() && isBugCategory(support)) {
+        boolean isNotOwner = !memberInfo.getMemberId().equals(support.getMemberId());
+        boolean isNotAdmin = !memberInfo.isAdminRole();
+        boolean isBugCategory = isBugCategory(support);
+
+        if (isNotOwner && isNotAdmin && isBugCategory) {
             throw new BaseException(ErrorCode.ACCESS_DENIED);
         }
     }


### PR DESCRIPTION
## Summary

> #697

문의 게시판에서 오류와 관련한 문의는 작성자를 제외한 일반 사용자는 접근하지 못하도록 설정해두었으나, 자신이 작성한 오류 문의 글을 상세 조회할 경우 마찬가지로 접근 불가 메시지가 뜨는 것을 확인하였으며, 이를 수정하였습니다.

## Tasks

- SupportDetailsRetrievalService 수정
  - 정보 접근을 허용할지 검사하는 로직에서 로그인한 사용자와 문의글 작성자의 id가 동일한지 비교하는 로직을 추가.
