### PR TITLE
refactor: CommentMyResponseDto의 writer 필드를 writerName으로 변경 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/community/comment/application/dto/mapper/CommentDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/community/comment/application/dto/mapper/CommentDtoMapper.java
@@ -36,7 +36,7 @@ public class CommentDtoMapper {
             .id(comment.getId())
             .boardId(boardInfo.getBoardId())
             .boardCategory(boardInfo.getCategory().getKey())
-            .writer(comment.isWantAnonymous() ? comment.getNickname() : memberInfo.getMemberName())
+            .writerName(comment.isWantAnonymous() ? comment.getNickname() : memberInfo.getMemberName())
             .writerImageUrl(comment.isWantAnonymous() ? null : memberInfo.getImageUrl())
             .content(comment.getContent())
             .likes(comment.getLikes())

--- a/src/main/java/page/clab/api/domain/community/comment/application/dto/response/CommentMyResponseDto.java
+++ b/src/main/java/page/clab/api/domain/community/comment/application/dto/response/CommentMyResponseDto.java
@@ -11,7 +11,7 @@ public class CommentMyResponseDto {
     private Long id;
     private Long boardId;
     private String boardCategory;
-    private String writer;
+    private String writerName;
     private String writerImageUrl;
     private String content;
     private Long likes;


### PR DESCRIPTION
## Summary

> #706 

CommentMyResponseDto의 writer 필드 네이밍을 writerName으로 변경하였습니다.

## Tasks

- CommentMyResponseDto의 writer 필드 네이밍을 writerName으로 변경하였습니다.

## Screenshot

<img width="697" height="533" alt="image" src="https://github.com/user-attachments/assets/76493176-76c7-4464-b03e-3cd5f95488bd" />
