### PR TITLE
feat: 대출 취소 기능 추가 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanCancelController.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/adapter/in/web/BookLoanCancelController.java
@@ -1,0 +1,31 @@
+package page.clab.api.domain.library.bookLoanRecord.adapter.in.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import page.clab.api.domain.library.bookLoanRecord.application.port.in.CancelBookLoanUseCase;
+import page.clab.api.global.common.dto.ApiResponse;
+
+@RestController
+@RequestMapping("/api/v1/book-loan-records")
+@RequiredArgsConstructor
+@Tag(name = "Library - Book Loan", description = "도서관 도서 대출")
+public class BookLoanCancelController {
+
+    private final CancelBookLoanUseCase cancelBookLoanUseCase;
+
+    @Operation(summary = "[U] 도서 대출 요청 취소", description = "ROLE_USER 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('USER')")
+    @DeleteMapping("/{bookLoanRecordId}")
+    public ApiResponse<Long> cancelBookLoan(
+        @PathVariable(name = "bookLoanRecordId") Long bookLoanRecordId
+    ) {
+        Long id = cancelBookLoanUseCase.cancelBookLoan(bookLoanRecordId);
+        return ApiResponse.success(id);
+    }
+}

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/application/port/in/CancelBookLoanUseCase.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/application/port/in/CancelBookLoanUseCase.java
@@ -1,0 +1,6 @@
+package page.clab.api.domain.library.bookLoanRecord.application.port.in;
+
+public interface CancelBookLoanUseCase {
+
+    Long cancelBookLoan(Long bookLoanRecordId);
+}

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/application/service/BookLoanCancelService.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/application/service/BookLoanCancelService.java
@@ -1,0 +1,30 @@
+package page.clab.api.domain.library.bookLoanRecord.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import page.clab.api.domain.library.bookLoanRecord.application.port.in.CancelBookLoanUseCase;
+import page.clab.api.domain.library.bookLoanRecord.application.port.out.RegisterBookLoanRecordPort;
+import page.clab.api.domain.library.bookLoanRecord.application.port.out.RetrieveBookLoanRecordPort;
+import page.clab.api.domain.library.bookLoanRecord.domain.BookLoanRecord;
+import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
+
+@Service
+@RequiredArgsConstructor
+public class BookLoanCancelService implements CancelBookLoanUseCase {
+
+    private final RetrieveBookLoanRecordPort retrieveBookLoanRecordPort;
+    private final ExternalRetrieveMemberUseCase externalRetrieveMemberUseCase;
+    private final RegisterBookLoanRecordPort registerBookLoanRecordPort;
+
+    @Transactional
+    @Override
+    public Long cancelBookLoan(Long bookLoanRecordId) {
+        BookLoanRecord bookLoanRecord = retrieveBookLoanRecordPort.getById(bookLoanRecordId);
+        bookLoanRecord.validateAccessPermission(externalRetrieveMemberUseCase.getCurrentMemberDetailedInfo());
+
+        bookLoanRecord.cancel();
+
+        return registerBookLoanRecordPort.save(bookLoanRecord).getId();
+    }
+}

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/domain/BookLoanRecord.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/domain/BookLoanRecord.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberBorrowerInfoDto;
+import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberDetailedInfoDto;
 import page.clab.api.global.exception.BaseException;
 import page.clab.api.global.exception.ErrorCode;
 
@@ -86,5 +87,22 @@ public class BookLoanRecord {
             throw new BaseException(ErrorCode.BOOK_LOAN_STATUS_NOT_PENDING);
         }
         this.status = BookLoanStatus.REJECTED;
+    }
+
+    public void cancel() {
+        if (this.status != BookLoanStatus.PENDING) {
+            throw new BaseException(ErrorCode.BOOK_LOAN_STATUS_NOT_PENDING);
+        }
+        this.status = BookLoanStatus.CANCELLED;
+    }
+
+    public boolean isOwner(String memberId) {
+        return this.borrowerId.equals(memberId);
+    }
+
+    public void validateAccessPermission(MemberDetailedInfoDto memberInfo) {
+        if (!isOwner(memberInfo.getMemberId()) && !memberInfo.isAdminRole()) {
+            throw new BaseException(ErrorCode.PERMISSION_DENIED, "해당 도서 대출을 취소할 권한이 없습니다.");
+        }
     }
 }

--- a/src/main/java/page/clab/api/domain/library/bookLoanRecord/domain/BookLoanStatus.java
+++ b/src/main/java/page/clab/api/domain/library/bookLoanRecord/domain/BookLoanStatus.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum BookLoanStatus {
 
     PENDING("PENDING", "대출 신청"),
+    CANCELLED("CANCELLED", "대출 취소"),
     APPROVED("APPROVED", "대출 승인"),
     REJECTED("REJECTED", "대출 거절"),
     RETURNED("RETURNED", "반납 완료");


### PR DESCRIPTION
## Summary

> #709 

도서 대출을 취소하는 기능을 추가하였습니다.

## Tasks

- 도서 상태에 대출 취소 `CANCELLED` 추가
- 도서 대출 취소 기능 구현

## ETC

기존 테이블에 `CANCELLED` 상태가 없어 제약 위반이 발생하므로 기존 DB를 따로 수정해주어야 합니다.

## Screenshot

도서 대출을 취소할 경우의 Swagger 화면입니다.
<img width="1437" height="881" alt="image" src="https://github.com/user-attachments/assets/a416891e-101b-4b6b-9ff0-c1a50b5c812a" />

