### PR TITLE
refactor: redirectId 반환 추가 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/community/accuse/application/dto/mapper/AccuseDtoMapper.java
+++ b/src/main/java/page/clab/api/domain/community/accuse/application/dto/mapper/AccuseDtoMapper.java
@@ -31,21 +31,23 @@ public class AccuseDtoMapper {
             .build();
     }
 
-    public AccuseMyResponseDto toDto(Accuse accuse) {
+    public AccuseMyResponseDto toDto(Accuse accuse, Long redirectId) {
         return AccuseMyResponseDto.builder()
             .targetType(accuse.getTarget().getTargetType())
             .targetId(accuse.getTarget().getTargetReferenceId())
+            .redirectId(redirectId)
             .reason(accuse.getReason())
             .accuseStatus(accuse.getTarget().getAccuseStatus())
             .createdAt(accuse.getTarget().getCreatedAt())
             .build();
     }
 
-    public AccuseResponseDto toDto(Accuse accuse, List<MemberBasicInfoDto> members) {
+    public AccuseResponseDto toDto(Accuse accuse, List<MemberBasicInfoDto> members, Long redirectId) {
         return AccuseResponseDto.builder()
             .members(members)
             .targetType(accuse.getTarget().getTargetType())
             .targetId(accuse.getTarget().getTargetReferenceId())
+            .redirectId(redirectId)
             .reason(accuse.getReason())
             .accuseStatus(accuse.getTarget().getAccuseStatus())
             .accuseCount(accuse.getTarget().getAccuseCount())

--- a/src/main/java/page/clab/api/domain/community/accuse/application/dto/response/AccuseMyResponseDto.java
+++ b/src/main/java/page/clab/api/domain/community/accuse/application/dto/response/AccuseMyResponseDto.java
@@ -12,6 +12,7 @@ public class AccuseMyResponseDto {
 
     private TargetType targetType;
     private Long targetId;
+    private Long redirectId;
     private String reason;
     private AccuseStatus accuseStatus;
     private LocalDateTime createdAt;

--- a/src/main/java/page/clab/api/domain/community/accuse/application/dto/response/AccuseResponseDto.java
+++ b/src/main/java/page/clab/api/domain/community/accuse/application/dto/response/AccuseResponseDto.java
@@ -15,6 +15,7 @@ public class AccuseResponseDto {
     private List<MemberBasicInfoDto> members;
     private TargetType targetType;
     private Long targetId;
+    private Long redirectId;
     private String reason;
     private AccuseStatus accuseStatus;
     private Long accuseCount;

--- a/src/main/java/page/clab/api/domain/community/accuse/application/service/AccusationRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/community/accuse/application/service/AccusationRetrievalService.java
@@ -17,6 +17,7 @@ import page.clab.api.domain.community.accuse.domain.AccuseStatus;
 import page.clab.api.domain.community.accuse.domain.AccuseTarget;
 import page.clab.api.domain.community.accuse.domain.TargetType;
 import page.clab.api.domain.memberManagement.member.application.dto.shared.MemberBasicInfoDto;
+import page.clab.api.external.community.comment.application.port.ExternalRetrieveCommentUseCase;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 import page.clab.api.global.common.dto.PagedResponseDto;
 
@@ -27,6 +28,7 @@ public class AccusationRetrievalService implements RetrieveAccusationUseCase {
     private final RetrieveAccusePort retrieveAccusePort;
     private final RetrieveAccuseTargetPort retrieveAccuseByTargetPort;
     private final ExternalRetrieveMemberUseCase externalRetrieveMemberUseCase;
+    private final ExternalRetrieveCommentUseCase externalRetrieveCommentUseCase;
     private final AccuseDtoMapper mapper;
 
     @Transactional(readOnly = true)
@@ -50,9 +52,17 @@ public class AccusationRetrievalService implements RetrieveAccusationUseCase {
                 List<MemberBasicInfoDto> members = accuses.stream()
                     .map(accuse -> externalRetrieveMemberUseCase.getMemberBasicInfoById(accuse.getMemberId()))
                     .toList();
-                return mapper.toDto(accuses.getFirst(), members);
+                Long redirectId = resolveRedirectId(accuses.getFirst());
+                return mapper.toDto(accuses.getFirst(), members, redirectId);
             })
             .filter(Objects::nonNull)
             .toList();
+    }
+
+    private Long resolveRedirectId(Accuse accuse) {
+        if (accuse.getTarget().getTargetType() == TargetType.COMMENT) {
+            return externalRetrieveCommentUseCase.getById(accuse.getTarget().getTargetReferenceId()).getBoardId();
+        }
+        return accuse.getTarget().getTargetReferenceId();
     }
 }

--- a/src/main/java/page/clab/api/domain/community/accuse/application/service/MyAccusationsService.java
+++ b/src/main/java/page/clab/api/domain/community/accuse/application/service/MyAccusationsService.java
@@ -10,6 +10,8 @@ import page.clab.api.domain.community.accuse.application.dto.response.AccuseMyRe
 import page.clab.api.domain.community.accuse.application.port.in.RetrieveMyAccusationsUseCase;
 import page.clab.api.domain.community.accuse.application.port.out.RetrieveAccusePort;
 import page.clab.api.domain.community.accuse.domain.Accuse;
+import page.clab.api.domain.community.accuse.domain.TargetType;
+import page.clab.api.external.community.comment.application.port.ExternalRetrieveCommentUseCase;
 import page.clab.api.external.memberManagement.member.application.port.ExternalRetrieveMemberUseCase;
 import page.clab.api.global.common.dto.PagedResponseDto;
 
@@ -19,6 +21,7 @@ public class MyAccusationsService implements RetrieveMyAccusationsUseCase {
 
     private final RetrieveAccusePort retrieveAccusePort;
     private final ExternalRetrieveMemberUseCase externalRetrieveMemberUseCase;
+    private final ExternalRetrieveCommentUseCase externalRetrieveCommentUseCase;
     private final AccuseDtoMapper mapper;
 
     @Transactional(readOnly = true)
@@ -26,6 +29,13 @@ public class MyAccusationsService implements RetrieveMyAccusationsUseCase {
     public PagedResponseDto<AccuseMyResponseDto> retrieveMyAccusations(Pageable pageable) {
         String currentMemberId = externalRetrieveMemberUseCase.getCurrentMemberId();
         Page<Accuse> accuses = retrieveAccusePort.findByMemberId(currentMemberId, pageable);
-        return new PagedResponseDto<>(accuses.map(mapper::toDto));
+        return new PagedResponseDto<>(accuses.map(accuse -> mapper.toDto(accuse, resolveRedirectId(accuse))));
+    }
+
+    private Long resolveRedirectId(Accuse accuse) {
+        if (accuse.getTarget().getTargetType() == TargetType.COMMENT) {
+            return externalRetrieveCommentUseCase.getById(accuse.getTarget().getTargetReferenceId()).getBoardId();
+        }
+        return accuse.getTarget().getTargetReferenceId();
     }
 }


### PR DESCRIPTION
## Summary

> #711 

신고 내역 조회 시 어느 페이지로 리다이렉트 해야할 지 알려주는 필드를 추가하였습니다.

## Tasks

- `AccuseMyresponseDto`와 AccuseResponseDto`에 redirectId 필드 추가
- `MyAccusationsService`와 `AccusationRetrievalService`에 redirectId를 조회하여 넘겨주는 로직 추가

## ETC

이슈 생성 당시 DB에 redirectId 컬럼을 추가하고 이를 조회하려고 했으나, DB 컬럼을 추가하는 것 대비 성능 향상이 크지 않을 것 같아 조회 로직을 통해 직접 조회하는 방향으로 개발 방향을 변경하였습니다.

## Screenshot

`api/v1/accusations/my`에서 targetId와는 별개로 redirectId가 추가된 모습입니다.
<img width="355" height="356" alt="image" src="https://github.com/user-attachments/assets/795071d5-c6b8-4182-934f-6664a8f78f7d" />

`api/v1/accusations`에서 targetId와는 별개로 redirectId가 추가된 모습입니다.
<img width="365" height="455" alt="image" src="https://github.com/user-attachments/assets/37b25c53-1bd6-407b-945c-f4a5da330175" />
